### PR TITLE
Control-socket must hold uid/gid variables rather than strings.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,7 +172,7 @@ class freeradius (
   # Install a couple of virtual servers needed on all FR installations
   if $control_socket == true {
     freeradius::site { 'control-socket':
-      source  => 'puppet:///modules/freeradius/sites-enabled/control-socket',
+      source => template('freeradius/sites-enabled/control-socket.erb'),
     }
   }
 

--- a/templates/sites-enabled/control-socket.erb
+++ b/templates/sites-enabled/control-socket.erb
@@ -53,12 +53,12 @@ listen {
 	#
 	#  Name of user that is allowed to connect to the control socket.
 	#
-	uid = radiusd
+	uid = <%= @fr_user %>
 
 	#
 	#  Name of group that is allowed to connect to the control socket.
 	#
-	gid = radiusd
+	gid = <%= @fr_group %>
 
 	#
 	#  Access mode.


### PR DESCRIPTION
To achieve this, we move control-socket to a template using the strings.
