### PR TITLE
Make an educated guess about the version of FR

### DIFF
--- a/manifests/attr.pp
+++ b/manifests/attr.pp
@@ -11,9 +11,10 @@ define freeradius::attr (
   $fr_group            = $::freeradius::params::fr_group
   $fr_moduleconfigpath = $::freeradius::params::fr_moduleconfigpath
   $fr_modulepath       = $::freeradius::params::fr_modulepath
+  $fr_version          = $::freeradius::params::fr_version
 
   # Decide on location for attribute filters
-  $location = $::freeradius_maj_version ? {
+  $location = $fr_version ? {
     2       => $fr_basepath,
     3       => "${fr_moduleconfigpath}/attr_filter",
     default => $fr_moduleconfigpath,
@@ -33,7 +34,7 @@ define freeradius::attr (
   # Reference all attribute snippets in one file
   concat::fragment { "attr-${name}":
     target  => "${fr_modulepath}/attr_filter",
-    content => template("freeradius/attr.fr${::freeradius_maj_version}.erb"),
+    content => template("freeradius/attr.fr${fr_version}.erb"),
     order   => 20,
   }
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -17,13 +17,14 @@ define freeradius::client (
   $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
+  $fr_version  = $::freeradius::params::fr_version
 
   file { "${fr_basepath}/clients.d/${shortname}.conf":
     ensure  => $ensure,
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
-    content => template("freeradius/client.conf.fr${::freeradius_maj_version}.erb"),
+    content => template("freeradius/client.conf.fr${fr_version}.erb"),
     require => [File["${fr_basepath}/clients.d"], Group[$fr_group]],
     notify  => Service[$fr_service],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class freeradius (
     mode    => '0640',
     owner   => 'root',
     group   => $freeradius::fr_group,
-    content => template("freeradius/radiusd.conf.fr${::freeradius_maj_version}.erb"),
+    content => template("freeradius/radiusd.conf.fr${freeradius::fr_version}.erb"),
     require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
     notify  => Service[$freeradius::fr_service],
   }
@@ -115,8 +115,8 @@ class freeradius (
 
   # Install default attribute filters
   concat::fragment { "attr-default":
-    target  => "${fr_modulepath}/attr_filter",
-    content => template("freeradius/attr_default.fr${::freeradius_maj_version}.erb"),
+    target  => "${freeradius::fr_modulepath}/attr_filter",
+    content => template("freeradius/attr_default.fr${freeradius::fr_version}.erb"),
     order   => 10,
   }
 

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -25,6 +25,7 @@ define freeradius::ldap (
   $fr_service          = $::freeradius::params::fr_service
   $fr_modulepath       = $::freeradius::params::fr_modulepath
   $fr_group            = $::freeradius::params::fr_group
+  $fr_version          = $::freeradius::params::fr_version
 
   # Validate our inputs
   # Hostnames
@@ -68,7 +69,7 @@ define freeradius::ldap (
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
-    content => template("freeradius/ldap.fr${::freeradius_maj_version}.erb"),
+    content => template("freeradius/ldap.fr${fr_version}.erb"),
     require => [Package[$fr_package], Group[$fr_group]],
     notify  => Service[$fr_service],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,50 @@
 # Default parameters for freeradius
 class freeradius::params {
 
+  # Make an educated guess which version of FR we are running, based on the OS
+  case $::operatingsystem {
+    /RedHat|CentOS/: {
+      $fr_guessversion = $::operatingsystemmajrelease ? {
+        5       => 2,
+        6       => 2,
+        7       => 3,
+        default => 3,
+      }
+    }
+    'Debian': {
+      $fr_guessversion = $::operatingsystemmajrelease ? {
+        6       => 2,
+        7       => 2,
+        8       => 2,
+        default => 2,
+      }
+    }
+    'Fedora': {
+      $fr_guessversion = $::operatingsystemmajrelease ? {
+        21      => 3,
+        22      => 3,
+        23      => 3,
+        default => 3,
+      }
+    }
+    'Ubuntu': {
+      $fr_guessversion = $::operatingsystemmajrelease ? {
+        '14.04' => 2,
+        '14.10' => 2,
+        '15.04' => 2,
+        '15.10' => 2,
+        default => 2,
+      }
+    }
+  }
+
+  # Use the FR version fact if defined, otherwise use our best estimate from above
+  if $::freeradius_maj_version {
+    $fr_version = $::freeradius_maj_version
+  } else {
+    $fr_version = $fr_guessversion
+  }
+
   # Name of FreeRADIUS package
   $fr_package = $::osfamily ? {
     'RedHat' => 'freeradius',
@@ -37,9 +81,9 @@ class freeradius::params {
   }
 
   # Default module dir
-  $fr_moduledir = $::freeradius_version ? {
-    /^2\./    => 'modules',
-    /^3\./    => 'mods-enabled',
+  $fr_moduledir = $fr_version ? {
+    '2'       => 'modules',
+    '3'       => 'mods-enabled',
     default   => 'modules',
   }
 
@@ -47,9 +91,9 @@ class freeradius::params {
   $fr_modulepath = "${fr_basepath}/${fr_moduledir}"
 
   # Default module config dir
-  $fr_modconfigdir = $::freeradius_version ? {
-    /^2\./    => 'conf.d',
-    /^3\./    => 'mods-config',
+  $fr_modconfigdir = $fr_version ? {
+    '2'       => 'conf.d',
+    '3'       => 'mods-config',
     default   => 'conf.d',
   }
 

--- a/manifests/sql.pp
+++ b/manifests/sql.pp
@@ -35,6 +35,7 @@ define freeradius::sql (
   $fr_group            = $::freeradius::params::fr_group
   $fr_logpath          = $::freeradius::params::fr_logpath
   $fr_moduleconfigpath = $::freeradius::params::fr_moduleconfigpath
+  $fr_version          = $::freeradius::params::fr_version
 
   # Validate our inputs
   # Validate multiple choice options
@@ -79,9 +80,9 @@ define freeradius::sql (
   }
 
   # Determine default location of query file
-  $queryfile = $::freeradius_version ? {
-    /^2\./  => "${fr_basepath}/sql/${database}/dialup.conf",
-    /^3\./  => "${fr_basepath}/sql/queries.conf",
+  $queryfile = $fr_version ? {
+    '2'     => "${fr_basepath}/sql/${database}/dialup.conf",
+    '3'     => "${fr_basepath}/sql/queries.conf",
     default => "${fr_basepath}/sql/queries.conf",
   }
 
@@ -100,7 +101,7 @@ define freeradius::sql (
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
-    content => template("freeradius/sql.conf.fr${::freeradius_maj_version}.erb"),
+    content => template("freeradius/sql.conf.fr${fr_version}.erb"),
     require => [Package[$fr_package], Group[$fr_group]],
     notify  => Service[$fr_service],
   }

--- a/manifests/statusclient.pp
+++ b/manifests/statusclient.pp
@@ -12,13 +12,14 @@ define freeradius::statusclient (
   $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
+  $fr_version  = $::freeradius::params::fr_version
 
   file { "${fr_basepath}/statusclients.d/${name}.conf":
     ensure  => $ensure,
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
-    content => template("freeradius/client.conf.fr${::freeradius_maj_version}.erb"),
+    content => template("freeradius/client.conf.fr${fr_version}.erb"),
     require => [File["${fr_basepath}/clients.d"], Package[$fr_package], Group[$fr_group]],
     notify  => Service[$fr_service],
   }


### PR DESCRIPTION
Make an educated guess about the version of FR when the fact is unavailable (on the first run). Currently this causes problems because `$::freeradius_maj_version` is `undef` on the first run, before the `freeradius` package has been installed.

This change means on the first run, when the fact is undefined, it will make an educated guess about the version of FreeRADIUS by looking at the OS version.