### PR TITLE
Look for executable 'freeradius' where 'radiusd' doesn't exist

### DIFF
--- a/lib/facter/freeradius_maj_version.rb
+++ b/lib/facter/freeradius_maj_version.rb
@@ -2,6 +2,9 @@
 Facter.add(:freeradius_maj_version) do
   setcode do
     version = Facter::Core::Execution.exec('radiusd -v')
+    if version.nil?
+      version = Facter::Core::Execution.exec('freeradius -v')
+    end
     if !version.nil?
       version = version.split(/\n/)[0].match(/FreeRADIUS Version (\d)\.\d\.\d/)[1].to_s
     end

--- a/lib/facter/freeradius_version.rb
+++ b/lib/facter/freeradius_version.rb
@@ -2,6 +2,9 @@
 Facter.add(:freeradius_version) do
   setcode do
     version = Facter::Core::Execution.exec('radiusd -v')
+    if version.nil?
+      version = Facter::Core::Execution.exec('freeradius -v')
+    end
     if !version.nil?
       version = version.split(/\n/)[0].match(/FreeRADIUS Version (\d\.\d\.\d)/)[1].to_s
     end


### PR DESCRIPTION
On Debian, the radiusd executable is called freeradius.