### PR TITLE
LDAP multiple server fix

### DIFF
--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -38,7 +38,7 @@ define freeradius::ldap (
   #              server = 'ldap2.example.com'
   #              server = 'ldap3.example.com'
   $serverconcatarray = $::freeradius_version ? {
-    /^3\.0\./ => join($serverarray, ','),
+    /^3\.0\./ => any2array(join($serverarray, ',')),
     default   => $serverarray,
   }
 

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -37,7 +37,7 @@ define freeradius::ldap (
   # FR3.1 format server = 'ldap1.example.com'
   #              server = 'ldap2.example.com'
   #              server = 'ldap3.example.com'
-  $serverconcatarray = $::freeradiusversion ? {
+  $serverconcatarray = $::freeradius_version ? {
     /^3\.0\./ => join($serverarray, ','),
     default   => $serverarray,
   }

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -33,6 +33,15 @@ define freeradius::ldap (
     fail('$server must be an array of hostnames or IP addresses')
   }
 
+  # FR3.0 format server = 'ldap1.example.com, ldap1.example.com, ldap1.example.com'
+  # FR3.1 format server = 'ldap1.example.com'
+  #              server = 'ldap2.example.com'
+  #              server = 'ldap3.example.com'
+  $serverconcatarray = $::freeradiusversion ? {
+    /^3\.0\./ => join($serverarray, ','),
+    default   => $serverarray,
+  }
+
   # Fake booleans (FR uses yes/no instead of true/false)
   unless $starttls in ['yes', 'no'] {
     fail('$starttls must be yes or no')

--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -18,8 +18,7 @@ ldap <%= @name %> {
 	#    - ldapi:// (LDAP over Unix socket)
 	#    - ldapc:// (Connectionless LDAP)
 	#
-<% @serverarray.each do |srv| -%>       server = '<%= srv %>'
-<% end -%>
+	server =<% @serverarray.each do |srv| -%> <%= srv %><% end -%>
 
 	#  Port to connect on, defaults to 389, will be ignored for LDAP URIs.
 	port = <%= @port %>

--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -18,7 +18,7 @@ ldap <%= @name %> {
 	#    - ldapi:// (LDAP over Unix socket)
 	#    - ldapc:// (Connectionless LDAP)
 	#
-<% @serverarray.each do |srv| -%>       server = '<%= srv %>'
+<% @serverconcatarray.each do |srv| -%>       server = '<%= srv %>'
 <% end -%>
 
 	#  Port to connect on, defaults to 389, will be ignored for LDAP URIs.

--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -18,7 +18,8 @@ ldap <%= @name %> {
 	#    - ldapi:// (LDAP over Unix socket)
 	#    - ldapc:// (Connectionless LDAP)
 	#
-	server =<% @serverarray.each do |srv| -%> <%= srv %><% end -%>
+<% @serverarray.each do |srv| -%>       server = '<%= srv %>'
+<% end -%>
 
 	#  Port to connect on, defaults to 389, will be ignored for LDAP URIs.
 	port = <%= @port %>


### PR DESCRIPTION
Write out `ldap.conf` with different syntax for FreeRADIUS 3.0.x and 3.1.x