### PR TITLE
Fix compatibility with strict variable checking and version comparison on Puppet 4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,9 +13,7 @@ class freeradius (
   $preserve_mods   = true,
 ) inherits freeradius::params {
 
-  if ($freeradius::fr_version != 3) {
-    fail('This module is only compatible with FreeRADIUS 3')
-  }
+  validate_re($freeradius::fr_version, '^3', 'This module is only compatible with FreeRADIUS 3')
 
   if $control_socket == true {
     warning('Use of the control_socket parameter in the freeradius class is deprecated. Please use the freeradius::control_socket class instead.')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,7 @@ class freeradius::params {
   }
 
   # Use the FR version fact if defined, otherwise use our best estimate from above
-  if $::freeradius_maj_version {
+  if getvar('::freeradius_maj_version') {
     $fr_version = $::freeradius_maj_version
   } else {
     $fr_version = $fr_guessversion


### PR DESCRIPTION
Hi there! Thanks for this module.

I've just tried to integrate it into our Puppet 4 Enterprise environment. We have strict variable checking enabled and as such the if statement checking for the presence of this variable errors out. As per this blog post https://blog.yo61.com/test-for-undefined-fact-in-puppet-with-strict_variables/ I was able to overcome this.

Additionally, the version comparison check fails the explicit != so I have replaced with a validate_re which does the trick. There may be a trailing special char or something which now fails on the far more strict Puppet 4 environment.

Both of these rely only on stdlib and I'm fairly sure they should remain compatible with Puppet 3 but the changes have only been tested on 4. 