### PR TITLE
Fix validate_re on guessed fact run

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,35 +5,35 @@ class freeradius::params {
   case $::operatingsystem {
     /RedHat|CentOS/: {
       $fr_guessversion = $::operatingsystemmajrelease ? {
-        5       => 2,
-        6       => 2,
-        7       => 3,
-        default => 3,
+        5       => '2',
+        6       => '2',
+        7       => '3',
+        default => '3',
       }
     }
     'Debian': {
       $fr_guessversion = $::operatingsystemmajrelease ? {
-        6       => 2,
-        7       => 2,
-        8       => 2,
-        default => 2,
+        6       => '2',
+        7       => '2',
+        8       => '2',
+        default => '2',
       }
     }
     'Fedora': {
       $fr_guessversion = $::operatingsystemmajrelease ? {
-        21      => 3,
-        22      => 3,
-        23      => 3,
-        default => 3,
+        21      => '3',
+        22      => '3',
+        23      => '3',
+        default => '3',
       }
     }
     'Ubuntu': {
       $fr_guessversion = $::operatingsystemmajrelease ? {
-        '14.04' => 2,
-        '14.10' => 2,
-        '15.04' => 2,
-        '15.10' => 2,
-        default => 2,
+        '14.04' => '2',
+        '14.10' => '2',
+        '15.04' => '2',
+        '15.10' => '2',
+        default => '2',
       }
     }
   }


### PR DESCRIPTION
I am so sorry!

I thought I had tested this thoroughly but it turns out that on a guessed puppet run(ie before the package is installed) with my validate_re change it crashes out because it tries to compare a string to a fixednum in puppet 4. Turning the guessed versions into a string does fix this.

Many many apologies for the incomplete pull request yesterday, I know this takes your precious time to review.