### PR TITLE
test for the existance of the pidfile before trying to HUP the daemon

### DIFF
--- a/templates/radiusd.logrotate.erb
+++ b/templates/radiusd.logrotate.erb
@@ -56,5 +56,5 @@
 }
 
 lastrotate
-	kill -HUP `cat /var/run/radiusd/radiusd.pid`
+	if [ -e /var/run/radiusd/radiusd.pid ] then; kill -HUP `cat /var/run/radiusd/radiusd.pid`; fi;
 endscript


### PR DESCRIPTION
This takes care of the situation where the daemon isn't running and logrotate tries to rotate the logfiles.  See uob#133