### PR TITLE
Fix libdir path

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -127,4 +127,10 @@ class freeradius::params {
     'Debian' => 'winbindd_priv',
     default  => 'wbpriv',
   }
+
+  $fr_libdir = $::osfamily ? {
+    'RedHat' => '/usr/lib64/freeradius',
+    'Debian' => '/usr/lib/freeradius',
+    default  => '/usr/lib64/freeradius',
+  }
 }

--- a/templates/radiusd.conf.erb
+++ b/templates/radiusd.conf.erb
@@ -104,7 +104,7 @@ db_dir = ${localstatedir}/lib/radiusd
 #	make
 #	make install
 #
-libdir = /usr/lib64/freeradius
+libdir = <%= @fr_libdir %>
 
 #  pidfile: Where to place the PID of the RADIUS server.
 #


### PR DESCRIPTION
Debian uses /usr/lib/freeradius as libpath. The current puppet module doesn't work with the packages from 1labs. This commit adds a $libdir variable, which is evaluated and used in  `radiusd.conf.erb`.