### PR TITLE
Add correct_escapes=true to radiusd.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class freeradius (
   $syslog          = false,
   $log_auth        = 'no',
   $preserve_mods   = true,
+  $correct_escapes = true,
 ) inherits freeradius::params {
 
   validate_re($freeradius::fr_version, '^3', 'This module is only compatible with FreeRADIUS 3')

--- a/templates/radiusd.conf.erb
+++ b/templates/radiusd.conf.erb
@@ -117,6 +117,27 @@ libdir = /usr/lib64/freeradius
 #
 pidfile = ${run_dir}/${name}.pid
 
+#
+#  correct_escapes: use correct backslash escaping
+#
+#  Prior to version 3.0.5, the handling of backslashes was a little
+#  awkward, i.e. "wrong".  In some cases, to get one backslash into
+#  a regex, you had to put 4 in the config files.
+#
+#  Version 3.0.5 fixes that.  However, for backwards compatibility,
+#  the new method of escaping is DISABLED BY DEFAULT.  This means
+#  that upgrading to 3.0.5 won't break your configuration.
+#
+#  If you don't have double backslashes (i.e. \\) in your configuration,
+#  this won't matter to you.  If you do have them, fix that to use only
+#  one backslash, and then set "correct_escapes = true".
+#
+#  You can check for this by doing:
+#
+#  $ grep '\\\\' $(find raddb -type f -print)
+#
+correct_escapes = true
+
 #  panic_action: Command to execute if the server dies unexpectedly.
 #
 #  FOR PRODUCTION SYSTEMS, ACTIONS SHOULD ALWAYS EXIT.

--- a/templates/radiusd.conf.erb
+++ b/templates/radiusd.conf.erb
@@ -136,7 +136,7 @@ pidfile = ${run_dir}/${name}.pid
 #
 #  $ grep '\\\\' $(find raddb -type f -print)
 #
-correct_escapes = true
+correct_escapes = <%= @correct_escapes %>
 
 #  panic_action: Command to execute if the server dies unexpectedly.
 #


### PR DESCRIPTION
Currently the regex escape sequences of policy.d/filters doesn't work with 1lab packages on jessie. This enables correct_escapes=true in radius.d conf.

The following shipped filter doesn't work, with the shipped puppet configuration:

```
#  reject double dots
#  e.g. "user@site..com"
if (&User-Name =~ /\.\./ ) {
...
```