### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ of the global settings to increase flexibility. Patches are welcome.
 ##### `control_socket`
 Use of the control_socket parameter in the freeradius class is deprecated. Use the `freeradius::control_socket` class instead.
 
+##### `correct_escapes`
+Use correct backslash escaping in unlang. Default: `true`
+
 ##### `max_requests`
 The maximum number of requests which the server keeps track of. This should be 256 multiplied by the number of clients. Default: `4096`
 
@@ -271,7 +274,7 @@ Default: `undef`.
 The IPv6 address of the client or range in CIDR format. `ip` and `ip6` are mutually exclusive but one must be supplied. Default: `undef`.
 
 ##### `shortname`
-A short alias that is used in place of the IP address or fully qualified hostname provided in the first line of the section. Required.
+A short alias that is used in place of the IP address or fully qualified hostname provided in the first line of the section. Defaults to resource name.
 
 ##### `secret`
 The RADIUS shared secret used for communication between the client/NAS and the RADIUS server. Required.


### PR DESCRIPTION
Adding documentation for optional freeradius::client::shortname and freeradius::correct_escapes parameters.