### PR TITLE
Fix for freeradius::module::eap

### DIFF
--- a/types/integer.pp
+++ b/types/integer.pp
@@ -1,0 +1,4 @@
+type Freeradius::Integer = Variant[
+  Pattern[/^\$\{.+\}$/],
+  Integer,
+]


### PR DESCRIPTION
This definition uses the defined type Freeradius::Integer, but it was not included in the previous PR.
This type (which could be used in other parameter definitions) is equal to an integer or a string starting with '$' (to be able to use variable references)