### PR TITLE
Add a more exhaustive list of parameters to ldap

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
        * [`freeradius::home_server_pool`](#freeradiushomeserverpool)
        * [`freeradius::instantiate`](#freeradiusinstantiate)
        * [`freeradius::ldap`](#freeradiusldap)
+       * [`freeradius::module::ldap`](#freeradiusmoduleldap)
        * [`freeradius::krb5`](#freeradiuskrb5)
        * [`freeradius::module`](#freeradiusmodule)
        * [`freeradius::policy`](#freeradiuspolicy)
@@ -439,14 +440,30 @@ freeradius::instantiate { 'mymodule': }
 ```
 
 #### `freeradius::ldap`
+Deprecated. Use `freeradius::module::ldap` instead.
+
+#### `freeradius::module::ldap`
 
 Configure LDAP support for FreeRADIUS
+
+##### `ensure`
+
+Whether the site should be present or not.
 
 ##### `identity`
 LDAP account for searching the directory. Required.
 
 ##### `password`
 Password for the `identity` account. Required.
+
+##### `sasl`
+SASL parameters to use for admin binds to the ldap server. This is a hash with 3 possible keys:
+
+* `mech`: The SASL mechanism used.
+* `proxy`: SASL authorizatino identity to proxy.
+* `realm`: SASL realm (used for kerberos)
+
+Default: `{}`
 
 ##### `basedn`
 Unless overridden in another section, the dn from which all searches will start from. Required.
@@ -458,9 +475,126 @@ server certificate, if you're using ldaps. Default: [`localhost`]
 ##### `port`
 Port to connect to the LDAP server on. Default: `389`
 
+##### `valuepair_attribute`
+Generic valuepair attribute. If set, this attribute will be retrieved in addition to any mapped attributes. Default: `undef`.
+
+##### `update`
+Array with mapping of LDAP directory attributes to RADIUS dictionary attributes. Default: `[]`
+
+##### `edir`
+Se to `yes` if you have eDirectory and want to use the universal password mechanisms. Possible values are `yes` and `no`. Default: `undef`.
+
+##### `edir_autz`
+Set to `yes`if you want to bind as the user after retrieving the Cleartest-Password. Possible values are `yes` and `no`. Default: `undef`.
+
+##### `user_base_dn`
+Where to start searching for users in the LDAP tree. Default: `${..base_dn}`.
+
+##### `user_filter`
+Filter for user objects. Default: `uid=%{%{Stripped-User-Name}-%{User-Name}})`
+
+##### `user_sasl`
+SASL parameters to use for user binds to the ldap server. This is a hash with 3 possible keys:
+
+* `mech`: The SASL mechanism used.
+* `proxy`: SASL authorizatino identity to proxy.
+* `realm`: SASL realm (used for kerberos)
+
+Default: `{}`
+
+##### `user_scope`
+Search scope for users. Valid values are `base`, `one`, `sub` and `children`. Default: `undef` (`sub` is applied).
+
+##### `user_sort_by`
+Server side result sorting. A list of space delimited attributes to order the result set by. Default: `undef`.
+
+##### `user_access_attribute`
+If this undefined, anyone is authorized. If it is defined, the contents of this attribute determine whether or not the user is authorised. Default: `undef`.
+
+##### `user_access_positive`
+Control whether the presence of 'access_attribute' allows access or denys access. Default: `undef`.
+
+##### `group_base_dn`
+Where to start searching for groups in the LDAP tree. Default: `${..base_dn}`.
+
+##### `group_filter`
+Filter for group objects. Default: `'(objectClass=posixGroup)'`.
+
+##### `group_scope`
+Search scope for groups. Valid values are `base`, `one`, `sub` and `children`. Default: `undef` (`sub` is applied).
+
+##### `group_name_attribute`
+Attribute that uniquely identifies a group. Default: `undef` (`'cn'` is applied).
+
+##### `group_membership_filter`
+Filter to find group objects a user is member of. That is, group objects with attributes that identify members (the inverse of `group_membership_attribute`). Default: `undef`.
+
+##### `group_membership_attribute`
+The attribute in user objects which contain the namos or DNs of groups a user is a member of. Default: `'memberOf'`.
+
+##### `group_cacheable_name`
+If `group_cacheable_name` or `group_cacheable_dn` are enabled, all group information for the user will be retrieved from the directory and written to LDAP-Group attributes appropiaate for the instance of rlm_ldap. Default: `undef`.
+
+##### `group_cacheable_dn`
+If `group_cacheable_name` or `group_cacheable_dn` are enabled, all group information for the user will be retrieved from the directory and written to LDAP-Group attributes appropiaate for the instance of rlm_ldap. Default: `undef`.
+
+##### `group_cache_attribute`
+Override the normal cache attribute (`<inst>-LDAP-Group` or `LDAP-Group` if using the default instance) and create a custom attribute. Default: `undef`.
+
+##### `group_attribute`
+Override the normal group comparison attribute name (`<inst>-LDAP-Group` or `LDAP-Group` if using the default instance). Default: `undef`.
+
+##### `profile_filter`
+Filter for RADIUS profile objects. Default: `undef`.
+
+##### `profile_default`
+The default profile. This may be a DN or an attribute reference. Default: `undef`.
+
+##### `profile_attribute`
+The LDAP attribute containing profile DNs to apply in addition to the default profile above. Default: `undef`.
+
+##### `client_base_dn`
+Where to start searching for clients in the LDAP tree. Default: `'${..base_dn}'`.
+
+##### `client_filter`
+Filter to match client objects. Default: `'(objectClass=radiusClient)'`.
+
+##### `client_scope`
+Search scope for clients. Valid values are `base`, `one`, `sub` and `children`. Default: `undef` (`sub` is applied).
+
+##### `read_clients`
+Load clients on startup. Default: `undef` (`'no'` is applied).
+
+##### `dereference`
+Control under which situations LDAP aliases are followed. May be one of `never`, `searching`, `finding` or `always`. Default: `undef` (`always` is applied).
+
+##### `chase_referrals`
+With `rebind` control whether the server follows references returned by LDAP directory. Mostly used for AD compatibility. Default: `yes`.
+
+##### `rebind`
+With `chase_referrals` control whether the server follows references returned by LDAP directory. Mostly used for AD compatibility. Default: `yes`.
+
+##### `use_referral_credentials`
+On rebind, use the credentials from the rebind url instead of admin credentials. Default: `no`.
+
+##### `session_tracking`
+If `'yes'`, then include draft-wahl-ldap-session tracking controls. Default: `undef`.
+
 ##### `uses`
 How many times the connection can be used before being re-established. This is useful for things
 like load balancers, which may exhibit sticky behaviour without it. `0` is unlimited. Default: `0`
+
+##### `retry_delay`
+The number of seconds to wait after the server tries to open a connection, and fails. Default: `30'.
+
+##### `lifetime`
+The lifetime (in seconds) of the connection. Default: `0` (forever).
+
+##### `idle_timeout`
+Idle timeout (in seconds). A connection which is unused for this length of time will be closed. Default: `60`.
+
+##### `connect_timeout`
+Connection timeout (in seconds). The maximum amount of time to wait for a new connection to be established. Default: `3.0`.
 
 ##### `idle`
 Sets the idle time before keepalive probes are sent. Default `60`
@@ -482,6 +616,12 @@ output of `radiusd -X` then it is supported. Otherwise, it is unsupported and ch
 
 ##### `timeout`
 Number of seconds to wait for LDAP query to finish. Default: `10`
+
+##### `timelimit`
+Seconds LDAP server has to process the query (server-side time limit). Default: `20`.
+
+##### `ldap_debug`
+Debug flag for LDAP SDK. Default: `0x0028`.
 
 ##### `start`
 Connections to create during module instantiation. If the server cannot create specified number of
@@ -511,6 +651,9 @@ Path to cert file for TLS
 
 ##### `keyfile`
 Path to key file for TLS
+
+##### `random_file`
+Random file used for TLS operations. Default: `undef` (`'/dev/urandom'` is used).
 
 ##### `requirecert`
 Certificate Verification requirements. Choose from:

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -21,65 +21,28 @@ define freeradius::ldap (
   $keyfile     = undef,
   $requirecert = 'allow',
 ) {
-  $fr_package          = $::freeradius::params::fr_package
-  $fr_service          = $::freeradius::params::fr_service
-  $fr_modulepath       = $::freeradius::params::fr_modulepath
-  $fr_group            = $::freeradius::params::fr_group
+  warning('The use of freeradius::ldap is deprecated. You must use freeradius::module::ldap instead')
 
-  # Validate our inputs
-  # Hostnames
-  $serverarray = any2array($server)
-  unless is_array($serverarray) {
-    fail('$server must be an array of hostnames or IP addresses')
-  }
-
-  # FR3.0 format server = 'ldap1.example.com, ldap1.example.com, ldap1.example.com'
-  # FR3.1 format server = 'ldap1.example.com'
-  #              server = 'ldap2.example.com'
-  #              server = 'ldap3.example.com'
-  $serverconcatarray = $::freeradius_version ? {
-    /^3\.0\./ => any2array(join($serverarray, ',')),
-    default   => $serverarray,
-  }
-
-  # Fake booleans (FR uses yes/no instead of true/false)
-  unless $starttls in ['yes', 'no'] {
-    fail('$starttls must be yes or no')
-  }
-
-  # Validate multiple choice options
-  unless $requirecert in ['never', 'allow', 'demand', 'hard'] {
-    fail('$requirecert must be one of never, allow, demand, hard')
-  }
-
-  # Validate integers
-  unless is_integer($port) {
-    fail('$port must be an integer')
-  }
-  unless is_integer($uses) {
-    fail('$uses must be an integer')
-  }
-  unless is_integer($idle) {
-    fail('$idle must be an integer')
-  }
-  unless is_integer($probes) {
-    fail('$probes must be an integer')
-  }
-  unless is_integer($interval) {
-    fail('$interval must be an integer')
-  }
-  unless is_integer($timeout) {
-    fail('$timeout must be an integer')
-  }
-
-  # Generate a module config, based on ldap.conf
-  file { "${fr_modulepath}/${name}":
-    ensure  => $ensure,
-    mode    => '0640',
-    owner   => 'root',
-    group   => $fr_group,
-    content => template('freeradius/ldap.erb'),
-    require => [Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+  freeradius::module::ldap {$name:
+    ensure      => $ensure,
+    identity    => $identity,
+    password    => $password,
+    basedn      => $basedn,
+    server      => $server,
+    port        => $port,
+    uses        => $uses,
+    idle        => $idle,
+    probes      => $probes,
+    interval    => $interval,
+    timeout     => $timeout,
+    start       => $start,
+    min         => $min,
+    max         => $max,
+    spare       => $spare,
+    starttls    => $starttls,
+    cafile      => $cafile,
+    certfile    => $certfile,
+    keyfile     => $keyfile,
+    requirecert => $requirecert,
   }
 }

--- a/manifests/module/ldap.pp
+++ b/manifests/module/ldap.pp
@@ -1,0 +1,85 @@
+# Configure LDAP support for FreeRADIUS
+define freeradius::module::ldap (
+  $identity,
+  $password,
+  $basedn,
+  $server      = ['localhost'],
+  $port        = 389,
+  $uses        = 0,
+  $idle        = 60,
+  $probes      = 3,
+  $interval    = 3,
+  $timeout     = 10,
+  $start       = '${thread[pool].start_servers}',
+  $min         = '${thread[pool].min_spare_servers}',
+  $max         = '${thread[pool].max_servers}',
+  $spare       = '${thread[pool].max_spare_servers}',
+  $ensure      = 'present',
+  $starttls    = 'no',
+  $cafile      = undef,
+  $certfile    = undef,
+  $keyfile     = undef,
+  $requirecert = 'allow',
+) {
+  $fr_package          = $::freeradius::params::fr_package
+  $fr_service          = $::freeradius::params::fr_service
+  $fr_modulepath       = $::freeradius::params::fr_modulepath
+  $fr_group            = $::freeradius::params::fr_group
+
+  # Validate our inputs
+  # Hostnames
+  $serverarray = any2array($server)
+  unless is_array($serverarray) {
+    fail('$server must be an array of hostnames or IP addresses')
+  }
+
+  # FR3.0 format server = 'ldap1.example.com, ldap1.example.com, ldap1.example.com'
+  # FR3.1 format server = 'ldap1.example.com'
+  #              server = 'ldap2.example.com'
+  #              server = 'ldap3.example.com'
+  $serverconcatarray = $::freeradius_version ? {
+    /^3\.0\./ => any2array(join($serverarray, ',')),
+    default   => $serverarray,
+  }
+
+  # Fake booleans (FR uses yes/no instead of true/false)
+  unless $starttls in ['yes', 'no'] {
+    fail('$starttls must be yes or no')
+  }
+
+  # Validate multiple choice options
+  unless $requirecert in ['never', 'allow', 'demand', 'hard'] {
+    fail('$requirecert must be one of never, allow, demand, hard')
+  }
+
+  # Validate integers
+  unless is_integer($port) {
+    fail('$port must be an integer')
+  }
+  unless is_integer($uses) {
+    fail('$uses must be an integer')
+  }
+  unless is_integer($idle) {
+    fail('$idle must be an integer')
+  }
+  unless is_integer($probes) {
+    fail('$probes must be an integer')
+  }
+  unless is_integer($interval) {
+    fail('$interval must be an integer')
+  }
+  unless is_integer($timeout) {
+    fail('$timeout must be an integer')
+  }
+
+  # Generate a module config, based on ldap.conf
+  file { "${fr_modulepath}/${name}":
+    ensure  => $ensure,
+    mode    => '0640',
+    owner   => 'root',
+    group   => $fr_group,
+    content => template('freeradius/ldap.erb'),
+    require => [Package[$fr_package], Group[$fr_group]],
+    notify  => Service[$fr_service],
+  }
+}

--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -26,8 +26,12 @@ ldap <%= @name %> {
 
 	#  Administrator account for searching and possibly modifying.
 	#  If using SASL + KRB5 these should be commented out.
-        identity = '<%= @identity %>'
-        password = '<%= @password %>'
+<%- if @identity -%>
+  identity = '<%= @identity %>'
+<%- end -%>
+<%- if @password -%>
+  password = <%= @password %>
+<%- end -%>
 
 	#  Unless overridden in another section, the dn from which all
 	#  searches will start from.
@@ -56,12 +60,21 @@ ldap <%= @name %> {
 	sasl {
 		# SASL mechanism
 #		mech = 'PLAIN'
+<%- if @sasl.has_key?('mech') -%>
+    mech = '<%= @sasl['mech'] %>'
+<%- end -%>
 
 		# SASL authorisation identity to proxy.
 #		proxy = 'autz_id'
+<%- if @sasl.has_key?('proxy') -%>
+    proxy = '<%= @sasl['proxy'] %>'
+<%- end -%>
 
 		# SASL realm. Used for kerberos.
 #		realm = 'example.org'
+<%- if @sasl.has_key?('realm') -%>
+    realm = '<%= @sasl['realm'] %>'
+<%- end -%>
 	}
 
 	#
@@ -82,6 +95,9 @@ ldap <%= @name %> {
 	# 			If the value is wrapped in double quotes it
 	#			will be xlat expanded.
 #	valuepair_attribute = 'radiusAttribute'
+<%- if @valuepair_attribute -%>
+  valuepair_attribute = <%= @valuepair_attribute %>
+<%- end -%>
 
 	#
 	#  Mapping of LDAP directory attributes to RADIUS dictionary attributes.
@@ -110,6 +126,11 @@ ldap <%= @name %> {
 	#  Note: LDAP attribute names should be single quoted unless you want
 	#  the name to be derived from an xlat expansion, or an attribute ref.
 	#
+<%- if @update -%>
+  update {
+    <%= @update.join("\n    ") %>
+  }
+<%- else -%>
 	update {
 		control:Password-With-Header	+= 'userPassword'
 #		control:NT-Password		:= 'ntPassword'
@@ -125,15 +146,22 @@ ldap <%= @name %> {
 		request:			+= 'radiusRequestAttribute'
 		reply:				+= 'radiusReplyAttribute'
 	}
+<%- end -%>
 
 	#  Set to yes if you have eDirectory and want to use the universal
 	#  password mechanism.
 #	edir = no
+<%- if @edir -%>
+  edir = <%= @edir %>
+<%- end -%>
 
 	#  Set to yes if you want to bind as the user after retrieving the
 	#  Cleartext-Password. This will consume the login grace, and
 	#  verify user authorization.
 #	edir_autz = no
+<%- if @edir_autz -%>
+  edir_autz = <%= @edir_autz %>
+<%- end -%>
 
 	#  Note: set_auth_type was removed in v3.x.x
 	#  Equivalent functionality can be achieved by adding the following
@@ -151,11 +179,11 @@ ldap <%= @name %> {
 	#
 	user {
 		#  Where to start searching in the tree for users
-		base_dn = "${..base_dn}"
+    base_dn = "<%= @user_base_dn %>"
 
 		#  Filter for user objects, should be specific enough
 		#  to identify a single user object.
-		filter = "(uid=%{%{Stripped-User-Name}:-%{User-Name}})"
+    filter = "<%= @user_filter %>"
 
 		#  SASL parameters to use for user binds
 		#
@@ -169,16 +197,28 @@ ldap <%= @name %> {
 		sasl {
 			# SASL mechanism
 #			mech = 'PLAIN'
+      <%- if @user_sasl.has_key?('mech') -%>
+      mech = '<%= @user_sasl['mech'] %>'
+      <%- end -%>
 
 			# SASL authorisation identity to proxy.
 #			proxy = &User-Name
+      <%- if @user_sasl.has_key?('proxy') -%>
+      proxy = '<%= @user_sasl['proxy'] %>'
+      <%- end -%>
 
 			# SASL realm. Used for kerberos.
 #			realm = 'example.org'
+      <%- if @user_sasl.has_key?('realm') -%>
+      realm = '<%= @user_sasl['realm'] %>'
+      <%- end -%>
 		}
 
 		#  Search scope, may be 'base', 'one', sub' or 'children'
 #		scope = 'sub'
+<%- if @user_scope -%>
+    scope = '<%= @user_scope %>'
+<%- end -%>
 
 		#  Server side result sorting
 		#
@@ -196,11 +236,17 @@ ldap <%= @name %> {
 		#  If a search returns multiple user objects and sort_by is not
 		#  set, the search will fail.
 #		sort_by = '-uid'
+<%- if @user_sort_by -%>
+    sort_by = '<%= @user_sort_by %>'
+<%- end -%>
 
 		#  If this is undefined, anyone is authorised.
 		#  If it is defined, the contents of this attribute
 		#  determine whether or not the user is authorised
 #		access_attribute = 'dialupAccess'
+<%- if @user_access_attribute -%>
+    access_attribute = '<%= @user_access_attribute %>'
+<%- end -%>
 
 		#  Control whether the presence of 'access_attribute'
 		#  allows access, or denys access.
@@ -225,6 +271,9 @@ ldap <%= @name %> {
 		#
 		#  Will result in the user being locked out.
 #		access_positive = yes
+<%- if @user_access_positive -%>
+    access_positive = <%= @user_access_positive %>
+<%- end -%>
 	}
 
 	#
@@ -232,24 +281,33 @@ ldap <%= @name %> {
 	#
 	group {
 		#  Where to start searching in the tree for groups
-		base_dn = "${..base_dn}"
+    base_dn = "<%= @group_base_dn %>"
 
 		#  Filter for group objects, should match all available
 		#  group objects a user might be a member of.
-		filter = '(objectClass=posixGroup)'
+    filter = "<%= @group_filter %>"
 
 		# Search scope, may be 'base', 'one', sub' or 'children'
 #		scope = 'sub'
+<%- if @group_scope -%>
+    scope = '<%= @group_scope %>'
+<%- end -%>
 
 		#  Attribute that uniquely identifies a group.
 		#  Is used when converting group DNs to group
 		#  names.
 #		name_attribute = cn
+<%- if @group_name_attribute -%>
+    name_attribute = <%= @group_name_attribute %>
+<%- end -%>
 
 		#  Filter to find group objects a user is a member of.
 		#  That is, group objects with attributes that
 		#  identify members (the inverse of membership_attribute).
 #		membership_filter = "(|(member=%{control:Ldap-UserDn})(memberUid=%{%{Stripped-User-Name}:-%{User-Name}}))"
+<%- if @group_membership_filter -%>
+    membership_filter = "<%= @group_membership_filter %>"
+<%- end -%>
 
 		#  The attribute in user objects which contain the names
 		#  or DNs of groups a user is a member of.
@@ -257,7 +315,7 @@ ldap <%= @name %> {
 		#  Unless a conversion between group name and group DN is
 		#  needed, there's no requirement for the group objects
 		#  referenced to actually exist.
-		membership_attribute = 'memberOf'
+    membership_attribute = '<%= @group_membership_attribute %>'
 
 		#  If cacheable_name or cacheable_dn are enabled,
 		#  all group information for the user will be
@@ -274,17 +332,29 @@ ldap <%= @name %> {
 		#  i.e. if your groups are specified as DNs then enable
 		#  cacheable_dn else enable cacheable_name.
 #		cacheable_name = 'no'
+<%- if @group_cacheable_name -%>
+    cacheable_name = '<%= @group_cacheable_name %>'
+<%- end -%>
 #		cacheable_dn = 'no'
+<%- if @group_cacheable_dn -%>
+    cacheable_dn = '<%= @group_cacheable_dn %>'
+<%- end -%>
 
 		#  Override the normal cache attribute (<inst>-LDAP-Group or
 		#  LDAP-Group if using the default instance) and create a
 		#  custom attribute.  This can help if multiple module instances
 		#  are used in fail-over.
 #		cache_attribute = 'LDAP-Cached-Membership'
+<%- if @group_cache_attribute -%>
+    cache_attribute = '<%= @group_cache_attribute %>'
+<%- end -%>
 
 		#  Override the normal group comparison attribute name
 		#  (<inst>-LDAP-Group or LDAP-Group if using the default instance) .
 #		group_attribute = "${.:instance}-${.:name}-Group"
+<%- if @group_attribute -%>
+    group_attribute = '<%= @group_attribute %>'
+<%- end -%>
 	}
 
 	#
@@ -295,6 +365,9 @@ ldap <%= @name %> {
 	profile {
 		#  Filter for RADIUS profile objects
 #		filter = '(objectclass=radiusprofile)'
+<%- if @profile_filter -%>
+    filter = '<%= @profile_filter %>'
+<%- end -%>
 
 		#  The default profile.  This may be a DN or an attribute
 		#  reference.
@@ -302,6 +375,9 @@ ldap <%= @name %> {
 		#  &User-Profile attribute to specify the default profile,
 		#  set this to &control:User-Profile.
 #		default = 'cn=radprofile,dc=example,dc=org'
+<%- if @profile_default -%>
+    default = '<%= @profile_default %>'
+<%- end -%>
 
 		#  The LDAP attribute containing profile DNs to apply
 		#  in addition to the default profile above.  These are
@@ -309,6 +385,9 @@ ldap <%= @name %> {
 		#  attributes from the update section, are are applied
 		#  if authorization is successful.
 #		attribute = 'radiusProfileDn'
+<%- if @profile_default -%>
+    attribute = '<%= @profile_attribute %>'
+<%- end -%>
 	}
 
 	#
@@ -316,15 +395,18 @@ ldap <%= @name %> {
 	#
 	client {
 		#   Where to start searching in the tree for clients
-		base_dn = "${..base_dn}"
+    base_dn = "<%= @client_base_dn %>"
 
 		#
 		#  Filter to match client objects
 		#
-		filter = '(objectClass=radiusClient)'
+    filter = '<%= @client_filter %>'
 
 		# Search scope, may be 'base', 'one', 'sub' or 'children'
 #		scope = 'sub'
+<%- if @client_scope -%>
+    scope = '<%= @client_scope %>'
+<%- end -%>
 
 		#
 		#  Sets default values (not obtained from LDAP) for new client entries
@@ -367,6 +449,9 @@ ldap <%= @name %> {
 
 	#  Load clients on startup
 #	read_clients = no
+<%- if @read_clients -%>
+  read_clients = <%= @read_clients %>
+<%- end -%>
 
 	#
 	#  Modify user object on receiving Accounting-Request
@@ -433,6 +518,9 @@ ldap <%= @name %> {
 		#
 		#  LDAP_OPT_DEREF is set to this value.
 #		dereference = 'always'
+<%- if @dereference -%>
+    dereference = '<%= @dereference %>'
+<%- end -%>
 
 		#
 		#  The following two configuration items control whether the
@@ -441,15 +529,15 @@ ldap <%= @name %> {
 		#  If you set these to 'no', then searches will likely return
 		#  'operations error', instead of a useful result.
 		#
-		chase_referrals = yes
-		rebind = yes
+    chase_referrals = <%= @chase_referrals %>
+    rebind = <%= @rebind %>
 
 		#
 		#  On rebind, use the credentials from the rebind url instead
 		#  of admin credentials used during the initial bind.
 		#  Default 'no'
 		#
-		use_referral_credentials = no
+    use_referral_credentials = <%= @use_referral_credentials %>
 
 		#
 		#  If 'yes', then include draft-wahl-ldap-session tracking
@@ -461,6 +549,9 @@ ldap <%= @name %> {
 		#  Default 'no'.
 		#
 #		session_tracking = yes
+<%- if @session_tracking -%>
+    session_tracking = <%= @session_tracking %>
+<%- end -%>
 
 		#  Seconds to wait for LDAP query to finish. default: 20
 		res_timeout = <%= @timeout %>
@@ -469,7 +560,7 @@ ldap <%= @name %> {
 		#  time limit). default: 20
 		#
 		#  LDAP_OPT_TIMELIMIT is set to this value.
-		srv_timelimit = 3
+    srv_timelimit = <%= @timelimit %>
 
 		#  LDAP_OPT_X_KEEPALIVE_IDLE
 		idle = <%= @idle %>
@@ -487,7 +578,7 @@ ldap <%= @name %> {
 		#
 		#	default: 0x0000 (no debugging messages)
 		#	Example:(LDAP_DEBUG_FILTER+LDAP_DEBUG_CONNS)
-		ldap_debug = 0x0028
+    ldap_debug = <%= @ldap_debug %>
 	}
 
 	#
@@ -519,6 +610,9 @@ ldap <%= @name %> {
 		private_key_file = <%= @keyfile %>
 <% end -%>
 #		random_file = /dev/urandom
+<%- if @random_file -%>
+    random_file = <%= @random_file %>
+<%- end -%>
 
 		#  Certificate Verification requirements.  Can be:
 		#    'never' (do not even bother trying)
@@ -581,19 +675,19 @@ ldap <%= @name %> {
 		#  The number of seconds to wait after the server tries
 		#  to open a connection, and fails.  During this time,
 		#  no new connections will be opened.
-		retry_delay = 30
+    retry_delay = <%= @retry_delay %>
 
 		#  The lifetime (in seconds) of the connection
-		lifetime = 0
+    lifetime = <%= @lifetime %>
 
 		#  Idle timeout (in seconds).  A connection which is
 		#  unused for this length of time will be closed.
-		idle_timeout = 60
+    idle_timeout = <%= @idle_timeout %>
 
 		#  Connection timeout (in seconds).  The maximum amount of
 		#  time to wait for a new connection to be established.
 		#  Sets LDAP_OPT_NETWORK_TIMEOUT in libldap.
-		connect_timeout = 3.0
+    connect_timeout = <%= @connect_timeout %>
 
 		#  NOTE: All configuration settings are enforced.  If a
 		#  connection is closed because of 'idle_timeout',

--- a/types/sasl.pp
+++ b/types/sasl.pp
@@ -1,0 +1,7 @@
+type Freeradius::Sasl = Struct[
+  {
+    mech  => Optional[String],
+    proxy => Optional[String],
+    realm => Optional[String],
+  },
+]

--- a/types/scope.pp
+++ b/types/scope.pp
@@ -1,0 +1,1 @@
+type Freeradius::Scope = Enum['base','one','sub','children']


### PR DESCRIPTION
I have completed the ldap define to be able to configure nearly all possible parameters of the ldap module.
In this reimplementation I have move ```freeradius::ldap``` to ```freeradius::module::ldap``` but maintaining the former with a deprecation warning (and calling the new). I have done this way because I think this _namespace_ is more appropiate than directly in ```freeradius```, but if you don't like I can change it and preserve the original ```freeradius::ldap```.