### PR TITLE
Fix freeradius service in debian systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,7 +69,7 @@ class freeradius::params {
   # Whether the FreeRADIUS init.d startup script has a status setting or not
   $fr_service_has_status = $::osfamily ? {
     'RedHat' => true,
-    'Debian' => false,
+    'Debian' => true,
     default  => false,
   }
 


### PR DESCRIPTION
freeradius init script do have status option in debian systems. Without this modification, freeradius is restarted when a config file is changed, but it not started if it is not running.