### PR TITLE
Remove secret parameter from freeradius::status_server

### DIFF
--- a/manifests/status_server.pp
+++ b/manifests/status_server.pp
@@ -1,6 +1,5 @@
 # Enable status-server
 class freeradius::status_server (
-  $secret,
   $port     = '18121',
   $listen   = '*',
 ) {


### PR DESCRIPTION
Although it is declared as mandatory, it is not used anywhere.