### PR TITLE
Fix db_dir option of radiusd.conf in debian systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -133,4 +133,14 @@ class freeradius::params {
     'Debian' => '/usr/lib/freeradius',
     default  => '/usr/lib64/freeradius',
   }
+
+  $fr_raddbdir = $::osfamily ? {
+    'Debian' => "\${sysconfdir}/freeradius",
+    default  => "\${sysconfdir}/raddb",
+  }
+
+  $fr_db_dir = $::osfamily ? {
+    'Debian' => "\${raddbdir}",
+    default  => "\${localstatedir}/lib/radiusd",
+  }
 }

--- a/templates/radiusd.conf.erb
+++ b/templates/radiusd.conf.erb
@@ -56,7 +56,7 @@ sysconfdir = /etc
 localstatedir = /var
 sbindir = /usr/sbin
 logdir = <%= @fr_logpath %>
-raddbdir = ${sysconfdir}/raddb
+raddbdir = <%= @fr_raddbdir %>
 radacctdir = ${logdir}/radacct
 
 #
@@ -70,7 +70,7 @@ certdir = ${confdir}/certs
 cadir   = ${confdir}/certs
 run_dir = ${localstatedir}/run/${name}
 
-db_dir = ${localstatedir}/lib/radiusd
+db_dir = <%= @fr_db_dir %>
 
 #
 # libdir: Where to find the rlm_* modules.


### PR DESCRIPTION
Config created was not correct because in debian based systems
use paths slightly different than others.