### PR TITLE
Add parameters to freeradius class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@ class freeradius (
   $preserve_mods   = true,
   $correct_escapes = true,
   $manage_logpath  = true,
+  $radacctdir      = $freeradius::params::radacctdir,
 ) inherits freeradius::params {
 
   validate_re($freeradius::fr_version, '^3', 'This module is only compatible with FreeRADIUS 3')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class freeradius (
   $log_auth        = 'no',
   $preserve_mods   = true,
   $correct_escapes = true,
+  $manage_logpath  = true,
 ) inherits freeradius::params {
 
   validate_re($freeradius::fr_version, '^3', 'This module is only compatible with FreeRADIUS 3')
@@ -276,20 +277,22 @@ class freeradius (
     }
   }
 
-  # Make the radius log dir traversable
-  file { [
-    $freeradius::fr_logpath,
-    "${freeradius::fr_logpath}/radacct",
-  ]:
-    mode    => '0750',
-    require => Package[$freeradius::fr_package],
-  }
+  if $manage_logpath {
+    # Make the radius log dir traversable
+    file { [
+      $freeradius::fr_logpath,
+      "${freeradius::fr_logpath}/radacct",
+    ]:
+      mode    => '0750',
+      require => Package[$freeradius::fr_package],
+    }
 
-  file { "${freeradius::fr_logpath}/radius.log":
-    owner   => $freeradius::fr_user,
-    group   => $freeradius::fr_group,
-    seltype => 'radiusd_log_t',
-    require => [Package[$freeradius::fr_package], User[$freeradius::fr_user], Group[$freeradius::fr_group]],
+    file { "${freeradius::fr_logpath}/radius.log":
+      owner   => $freeradius::fr_user,
+      group   => $freeradius::fr_group,
+      seltype => 'radiusd_log_t',
+      require => [Package[$freeradius::fr_package], User[$freeradius::fr_user], Group[$freeradius::fr_group]],
+    }
   }
 
   logrotate::rule { 'radacct':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -143,4 +143,6 @@ class freeradius::params {
     'Debian' => "\${raddbdir}",
     default  => "\${localstatedir}/lib/radiusd",
   }
+
+  $radacctdir = "\${logdir}/radacct"
 }

--- a/templates/radiusd.conf.erb
+++ b/templates/radiusd.conf.erb
@@ -57,7 +57,7 @@ localstatedir = /var
 sbindir = /usr/sbin
 logdir = <%= @fr_logpath %>
 raddbdir = <%= @fr_raddbdir %>
-radacctdir = ${logdir}/radacct
+radacctdir = <%= @radacctdir %>
 
 #
 #  name of the running server.  See also the "-n" command-line option.


### PR DESCRIPTION
This PR add two parameters to freeradius class:

1. ```$manage_logpath```: this parameter handle if logpath should be managed with puppet or not. It defaults to true, which correspond to previous behaviour. If set it to false, then ```radacct``` is not directly created/modified by puppet
1. ```$radacctdir```: With this parameter you can configure that path in freeradius. It defaults to ```${logdir}/radacct``` which is the _standard_ path.