### PR TITLE
Update for logrotate module dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,8 +37,8 @@
       "version_range": ">=3.0.0"
     },
     {
-      "name": "rodjek/logrotate",
-      "version_range": ">=1.1.1"
+      "name": "yo61/logrotate",
+      "version_range": ">=1.4.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
I was wondering if you would consider updating the logrotate module dependency.

This change would be good given changes for Puppet 4 (and sometime in the near-future Puppet 5).

The `rodjek/logrotate` module hasn't been updated for a number of years.

There is an active fork with fixes and updates applied https://github.com/yo61/puppet-logrotate
This fork also has `Approved` status on the Forge: https://forge.puppet.com/yo61/logrotate
