### PR TITLE
Add postgresql support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@ class freeradius (
   $max_servers     = '4096',
   $max_requests    = '4096',
   $mysql_support   = false,
+  $pgsql_support   = false,
   $perl_support    = false,
   $utils_support   = false,
   $ldap_support    = false,
@@ -212,6 +213,11 @@ class freeradius (
   }
   if $mysql_support {
     package { 'freeradius-mysql':
+      ensure => installed,
+    }
+  }
+  if $pgsql_support {
+    package { 'freeradius-postgresql':
       ensure => installed,
     }
   }


### PR DESCRIPTION
I was taking a quick look through your module and you don't appear to manage the `freeradius-postgresql` package required for the SQL module.

This change will start by installing the package required for `freeradius::sql` to use `database` as `postgresql`.