### PR TITLE
deploy modules and sites to their respective *-available directory

### DIFF
--- a/manifests/attr.pp
+++ b/manifests/attr.pp
@@ -25,7 +25,7 @@ define freeradius::attr (
 
   # Reference all attribute snippets in one file
   concat::fragment { "attr-${name}":
-    target  => "${fr_modulepath}/attr_filter",
+    target  => "${fr_basepath}/mods-available/attr_filter",
     content => template('freeradius/attr.erb'),
     order   => 20,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,17 +172,21 @@ class freeradius (
   }
 
   # Set up attribute filter file
-  concat { "${freeradius::fr_modulepath}/attr_filter":
+  concat { "${freeradius::fr_basepath}/mods-available/attr_filter":
     owner   => 'root',
     group   => $freeradius::fr_group,
     mode    => '0640',
     require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
     notify  => Service[$freeradius::fr_service],
   }
+  file { "${fr_modulepath}/attr_filter":
+    ensure => link,
+    target => "../mods-available/attr_filter",
+  }
 
   # Install default attribute filters
   concat::fragment { 'attr-default':
-    target  => "${freeradius::fr_modulepath}/attr_filter",
+    target  => "${freeradius::fr_basepath}/mods-available/attr_filter",
     content => template('freeradius/attr_default.erb'),
     order   => 10,
   }

--- a/manifests/krb5.pp
+++ b/manifests/krb5.pp
@@ -11,10 +11,11 @@ define freeradius::krb5 (
   $fr_package          = $::freeradius::params::fr_package
   $fr_service          = $::freeradius::params::fr_service
   $fr_modulepath       = $::freeradius::params::fr_modulepath
+  $fr_basepath         = $::freeradius::params::fr_basepath
   $fr_group            = $::freeradius::params::fr_group
 
   # Generate a module config
-  file { "${fr_modulepath}/${name}":
+  file { "${fr_basepath}/mods-availabe/${name}":
     ensure  => $ensure,
     mode    => '0640',
     owner   => 'root',
@@ -22,5 +23,9 @@ define freeradius::krb5 (
     content => template('freeradius/krb5.erb'),
     require => [Package[$fr_package], Group[$fr_group]],
     notify  => Service[$fr_service],
+  }
+  file { "${fr_modulepath}/${name}":
+    ensure => link,
+    target => "../mods-available/${name}",
   }
 }

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -18,8 +18,8 @@ define freeradius::module (
       target => "../mods-available/${name}",
     }
   } else {
-    # Deploy actual module to sites-enabled
-    file { "${fr_modulepath}/${name}":
+    # Deploy actual module to mods-available, and link it to mods-enabled
+    file { "${fr_basepath}/mods-available/${name}":
       ensure  => $ensure,
       mode    => '0640',
       owner   => 'root',
@@ -28,6 +28,10 @@ define freeradius::module (
       content => $content,
       require => [Package[$fr_package], Group[$fr_group]],
       notify  => Service[$fr_service],
+    }
+    file { "${fr_modulepath}/${name}":
+      ensure => link,
+      target => "../mods-available/${name}",
     }
   }
 }

--- a/manifests/module/ldap.pp
+++ b/manifests/module/ldap.pp
@@ -65,6 +65,7 @@ define freeradius::module::ldap (
   $fr_package          = $::freeradius::params::fr_package
   $fr_service          = $::freeradius::params::fr_service
   $fr_modulepath       = $::freeradius::params::fr_modulepath
+  $fr_basepath         = $::freeradius::params::fr_basepath
   $fr_group            = $::freeradius::params::fr_group
 
   # Validate our inputs
@@ -84,7 +85,7 @@ define freeradius::module::ldap (
   }
 
   # Generate a module config, based on ldap.conf
-  file { "${fr_modulepath}/${name}":
+  file { "${fr_basepath}/mods-available/${name}":
     ensure  => $ensure,
     mode    => '0640',
     owner   => 'root',
@@ -92,5 +93,9 @@ define freeradius::module::ldap (
     content => template('freeradius/ldap.erb'),
     require => [Package[$fr_package], Group[$fr_group]],
     notify  => Service[$fr_service],
+  }
+  file { "${fr_modulepath}/${name}":
+    ensure => link,
+    target => "../mods-available/${name}",
   }
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -26,7 +26,7 @@ define freeradius::site (
     default => undef,
   }
 
-  file { "${fr_basepath}/sites-enabled/${name}":
+  file { "${fr_basepath}/sites-available/${name}":
     ensure  => $ensure,
     mode    => '0640',
     owner   => 'root',
@@ -35,5 +35,9 @@ define freeradius::site (
     content => $manage_content,
     require => [Package[$fr_package], Group[$fr_group]],
     notify  => Service[$fr_service],
+  }
+  file { "${fr_basepath}/sites-enabled/${name}":
+    ensure => link,
+    target => "${fr_basepath}/sites-available/${name}",
   }
 }

--- a/manifests/sql.pp
+++ b/manifests/sql.pp
@@ -108,7 +108,7 @@ define freeradius::sql (
   }
 
   # Generate a module config, based on sql.conf
-  file { "${fr_modulepath}/${name}":
+  file { "${fr_basepath}/mods-available/${name}":
     ensure  => $ensure,
     mode    => '0640',
     owner   => 'root',
@@ -116,6 +116,10 @@ define freeradius::sql (
     content => template('freeradius/sql.conf.erb'),
     require => [Package[$fr_package], Group[$fr_group]],
     notify  => Service[$fr_service],
+  }
+  file { "${fr_modulepath}/${name}":
+    ensure => link,
+    target => "../mods-available/${name}",
   }
 
   # Install rotation for sqltrace if we are using it


### PR DESCRIPTION
sites:
- deploy files to sites-available and symlink to sites-enabled

modules:
- deploy modules to mod-available and symlink them to `$::freeradius::params::fr_modulepath`

There is further work to do to refactor the paths these files/links are deployed to, as `fr_modulepath` is currently derived from a selector based on the version of freeradius being deployed.

Refactoring references to `fr_modulepath` is a larger change than is required to fix #83, as it changes the interface this module presents to the outside world, and some deployments may be reliant on overriding `fr_modulepath` from outside this module.

