### PR TITLE
Fix link in absent modules

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -11,10 +11,15 @@ define freeradius::module (
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
+  $ensure_link = $ensure ? {
+    'absent' => 'absent',
+    default  => 'link'
+  }
+
   if ($preserve) {
     # Symlink to mods-available for stock modules
     file { "${fr_modulepath}/${name}":
-      ensure => link,
+      ensure => $ensure_link,
       target => "../mods-available/${name}",
     }
   } else {
@@ -30,7 +35,7 @@ define freeradius::module (
       notify  => Service[$fr_service],
     }
     file { "${fr_modulepath}/${name}":
-      ensure => link,
+      ensure => $ensure_link,
       target => "../mods-available/${name}",
     }
   }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -26,6 +26,11 @@ define freeradius::site (
     default => undef,
   }
 
+  $ensure_link = $ensure ? {
+    'absent' => 'absent',
+    default  => 'link'
+  }
+
   file { "${fr_basepath}/sites-available/${name}":
     ensure  => $ensure,
     mode    => '0640',
@@ -37,7 +42,7 @@ define freeradius::site (
     notify  => Service[$fr_service],
   }
   file { "${fr_basepath}/sites-enabled/${name}":
-    ensure => link,
+    ensure => $ensure_link,
     target => "${fr_basepath}/sites-available/${name}",
   }
 }


### PR DESCRIPTION
The link in mods-enabled directory should not be present is module has
`ensure => absent`.
The same applies to `freeradius::site`