### PR TITLE
Test provinding values as integers

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -311,7 +311,7 @@ class freeradius (
   logrotate::rule { 'radacct':
     path          => "${freeradius::fr_logpath}/radacct/*/*.log",
     rotate_every  => 'day',
-    rotate        => '7',
+    rotate        => 7,
     create        => false,
     missingok     => true,
     compress      => true,
@@ -322,7 +322,7 @@ class freeradius (
   logrotate::rule { 'checkrad':
     path          => "${freeradius::fr_logpath}/checkrad.log",
     rotate_every  => 'week',
-    rotate        => '1',
+    rotate        => 1,
     create        => true,
     missingok     => true,
     compress      => true,
@@ -333,7 +333,7 @@ class freeradius (
   logrotate::rule { 'radiusd':
     path          => "${freeradius::fr_logpath}/radius*.log",
     rotate_every  => 'week',
-    rotate        => '26',
+    rotate        => 26,
     create        => true,
     missingok     => true,
     compress      => true,


### PR DESCRIPTION
I'm implementing some new freeradius setups, and this module seems pretty much exactly what I need, except it fails to run complaining about:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Logrotate::Rule[radacct]: parameter 'rotate' expects a value of type Undef or Integer, got String at /etc/puppetlabs/code/environments/freeradius/modules/freeradius/manifests/init.pp:311 on node radius.ab2.staging.gigaclear.net
```

I made the obvious change as in this pull request, and it seems to fix the problem.  Yet there was
clearly a commit fba271f0ec83362547c4ed193eab0d9df1a8770a in 2015 that made exactly the opposite change, and this problem is such a clear show-stopper I must be missing something?

This is on CentOS 7, puppet-agent-1.10.8-1.el7.x86_64