### PR TITLE
Fix unbalanced brackets in the eap module

### DIFF
--- a/templates/eap.erb
+++ b/templates/eap.erb
@@ -135,8 +135,8 @@ eap {
   #  the users password will go over the wire in plain-text,
   #  for anyone to see.
   #
-<%- if @gtc_challenge -%>
   gtc {
+<%- if @gtc_challenge -%>
     #  The default challenge, which many clients
     #  ignore..
     challenge = "<%= @gtc_challenge %>"


### PR DESCRIPTION
Simply enabling the eap module like so:
```
    freeradius::module::eap { 'eap':
        ensure => 'present',
    }
```
results in a broken configuration:
```
...
including configuration file /etc/raddb/mods-enabled/eap
/etc/raddb/mods-enabled/eap[604]: Too many closing braces
Errors reading or parsing /etc/raddb/radiusd.conf
```

Move the opening `gtc {` outside the block that is conditional on the
definition of `@gtc_challenge`