### PR TITLE
Huntgroup

### DIFF
--- a/manifests/huntgroup.pp
+++ b/manifests/huntgroup.pp
@@ -13,7 +13,6 @@ define freeradius::huntgroup (
   $content    = "${huntgroup}\t${conditionals}\n"
 
   concat::fragment { "huntgroup.${title}":
-    ensure  => $ensure,
     target  => "${fr_basepath}/mods-config/preprocess/huntgroups",
     content => $content,
     order   => $order,

--- a/manifests/module/huntgroup.pp
+++ b/manifests/module/huntgroup.pp
@@ -3,11 +3,12 @@
 define freeradius::module::huntgroup (
   Variant[String,Array] $conditions,
   Variant[String,Integer] $order     = 50,
-  String $huntgroup                  = 'huntgroup',
+  Optional[String] $huntgroup        = undef,
 ) {
-  concat::fragment {"Huntgroup ${name}":
-    target  => $huntgroup,
-    order   => $order,
-    content => template('freeradius/huntgroup.erb'),
+  warning('Use of freeradius::module::huntgroup is deprecated. Use freeradius::huntgroup instead')
+
+  freeradius::huntgroup {$name:
+    conditions => $conditions,
+    order      => $order,
   }
 }

--- a/manifests/module/preprocess.pp
+++ b/manifests/module/preprocess.pp
@@ -19,20 +19,4 @@ class freeradius::module::preprocess (
     ensure  => $ensure,
     content => template('freeradius/preprocess.erb'),
   }
-
-
-  $huntgroup_path = $huntgroups ? {
-    "\${moddir}/huntgroups" => "${fr_moduleconfigpath}/preprocess/huntgroups",
-    default                 => $huntgroups,
-  }
-
-  concat {'huntgroup':
-    ensure  => $ensure,
-    path    => $huntgroup_path,
-    owner   => 'root',
-    group   => $fr_group,
-    mode    => '0640',
-    require => Freeradius::Module['preprocess'],
-    notify  => Service[$fr_service],
-  }
 }


### PR DESCRIPTION
There was duplicate functionality for huntgroups since #93. Since that PR, freeradius::module::preprocess and freeradius::module::huntgroup wasn't working.
This PR deprecates freeradius::module::preprocess (while still works).