### PR TITLE
Fix query_file path

### DIFF
--- a/manifests/sql.pp
+++ b/manifests/sql.pp
@@ -99,7 +99,7 @@ define freeradius::sql (
   $queryfile = "${fr_basepath}/sql/queries.conf"
 
   # Install custom query file
-  if ($custom_query_file != '') {
+  if ($custom_query_file and $custom_query_file != '') {
     $custom_query_file_path = "${fr_moduleconfigpath}/${name}-queries.conf"
 
     ::freeradius::config { "${name}-queries.conf":


### PR DESCRIPTION
$custom_query_file is initialized as undef, so this check implied custom_query_file was always used is sql module does not work if you don't manually configure custom_query_file.
This PR fixes this problem.