### PR TITLE
Fix huntgroups when there is more than one condition

### DIFF
--- a/manifests/huntgroup.pp
+++ b/manifests/huntgroup.pp
@@ -8,13 +8,9 @@ define freeradius::huntgroup (
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_service  = $::freeradius::params::fr_service
 
-  $conditionals = join($conditions, ', ')
-
-  $content    = "${huntgroup}\t${conditionals}\n"
-
   concat::fragment { "huntgroup.${title}":
     target  => "${fr_basepath}/mods-config/preprocess/huntgroups",
-    content => $content,
+    content => template('freeradius/huntgroup.erb'),
     order   => $order,
     notify  => Service[$fr_service],
   }

--- a/templates/huntgroup.erb
+++ b/templates/huntgroup.erb
@@ -1,10 +1,6 @@
 
-#
-##########################################################
-# Huntgroup Puppet Name: <%= @name %>
-#
 <%- if @conditions.is_a?(Array) -%>
-<%= @conditions.collect { |cond| @name + " " + cond }.join("\n") %>
+<%= @conditions.collect { |cond| @huntgroup + " " + cond }.join("\n") %>
 <%- else -%>
-<%= @name %> <%= @conditions %>
+<%= @huntgroup %> <%= @conditions %>
 <%- end -%>


### PR DESCRIPTION
In huntgroups, when there is more than one condition for a huntgroup, each condition should be indicated in one huntgroup line, instead of separated by commas.

In this PR I have also deleted the huntgroup template that is not needed anymore since PR#96.