### PR TITLE
Add support for Ubuntu 18.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -86,19 +86,11 @@ class freeradius::params {
     'Debian': {
       $fr_basepath = $::operatingsystemmajrelease ? {
         '9'     => '/etc/freeradius/3.0',
-        default => '/etc/freeradius',
-      }
-      $fr_raddbdir = $::operatingsystemmajrelease ? {
-        '9'     => "\${sysconfdir}/freeradius/3.0",
-        default => "\${sysconfdir}/freeradius",
-      }
-    }
-    'Ubuntu': {
-      $fr_basepath = $::operatingsystemmajrelease ? {
         '18.04'     => '/etc/freeradius/3.0',
         default => '/etc/freeradius',
       }
       $fr_raddbdir = $::operatingsystemmajrelease ? {
+        '9'     => "\${sysconfdir}/freeradius/3.0",
         '18.04'     => "\${sysconfdir}/freeradius/3.0",
         default => "\${sysconfdir}/freeradius",
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class freeradius::params {
         '14.10' => '2',
         '15.04' => '2',
         '15.10' => '2',
+        '18.04' => '3',
         default => '2',
       }
     }
@@ -89,6 +90,16 @@ class freeradius::params {
       }
       $fr_raddbdir = $::operatingsystemmajrelease ? {
         '9'     => "\${sysconfdir}/freeradius/3.0",
+        default => "\${sysconfdir}/freeradius",
+      }
+    }
+    'Ubuntu': {
+      $fr_basepath = $::operatingsystemmajrelease ? {
+        '18.04'     => '/etc/freeradius/3.0',
+        default => '/etc/freeradius',
+      }
+      $fr_raddbdir = $::operatingsystemmajrelease ? {
+        '18.04'     => "\${sysconfdir}/freeradius/3.0",
         default => "\${sysconfdir}/freeradius",
       }
     }


### PR DESCRIPTION
Ubuntu 18.04 do have freeradius 3.0. This makes the module use the correct paths.
Since it uses the same package as Debian not many changes are necessary.
