### PR TITLE
Add order parameter to realm class

### DIFF
--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -5,6 +5,7 @@ define freeradius::realm (
   $acct_pool = undef,
   $pool = undef,
   $nostrip = false,
+  $realm_order = 0,
 ) {
   $fr_basepath = $::freeradius::params::fr_basepath
 
@@ -17,6 +18,6 @@ define freeradius::realm (
   concat::fragment { "realm-${name}":
     target  => "${fr_basepath}/proxy.conf",
     content => template('freeradius/realm.erb'),
-    order   => 30,
+    order   => 30 + $realm_order,
   }
 }

--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -5,7 +5,7 @@ define freeradius::realm (
   $acct_pool = undef,
   $pool = undef,
   $nostrip = false,
-  $realm_order = 0,
+  $order = 30,
 ) {
   $fr_basepath = $::freeradius::params::fr_basepath
 
@@ -18,6 +18,6 @@ define freeradius::realm (
   concat::fragment { "realm-${name}":
     target  => "${fr_basepath}/proxy.conf",
     content => template('freeradius/realm.erb'),
-    order   => 30 + $realm_order,
+    order   => $order,
   }
 }


### PR DESCRIPTION
When using concat::fragment the fragments gets sorted using both the order attribute and the name. 
There are times you need to have the realms in a specific order and this sorting of fragments disrupts this intended order.

This is fixed in this PR by using adding a modifier parameter. A parameter that modifies the base order used by the fragment.
I used the name realm_order but I'm not that convinced that this is the right name for it. Maybe 'priority' or perhaps plain 'order' is good enough.