### PR TITLE
Always define ldap servers using multiple server lines

### DIFF
--- a/manifests/module/ldap.pp
+++ b/manifests/module/ldap.pp
@@ -76,15 +76,6 @@ define freeradius::module::ldap (
     fail('$server must be an array of hostnames or IP addresses')
   }
 
-  # FR3.0 format server = 'ldap1.example.com, ldap1.example.com, ldap1.example.com'
-  # FR3.1 format server = 'ldap1.example.com'
-  #              server = 'ldap2.example.com'
-  #              server = 'ldap3.example.com'
-  $serverconcatarray = $::freeradius_version ? {
-    /^3\.0\./ => any2array(join($serverarray, ',')),
-    default   => $serverarray,
-  }
-
   # Generate a module config, based on ldap.conf
   file { "${fr_basepath}/mods-available/${name}":
     ensure  => $ensure,

--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -18,8 +18,9 @@ ldap <%= @name %> {
 	#    - ldapi:// (LDAP over Unix socket)
 	#    - ldapc:// (Connectionless LDAP)
 	#
-<% @serverconcatarray.each do |srv| -%>	server = '<%= srv %>'
-<% end -%>
+<%- @serverarray.each do |srv| -%>
+	server = '<%= srv %>'
+<%- end -%>
 
 	#  Port to connect on, defaults to 389, will be ignored for LDAP URIs.
 	port = <%= @port %>


### PR DESCRIPTION
Using freeradius-3.0.13-9.el7_5.x86_64 I get this in logs:

```
Tue Oct 30 12:18:23 2018 : Warning: Listing multiple LDAP servers in the 'server' configuration item is deprecated and will be removed in a future release.  Use multiple 'server' configuration items instead
```