### PR TITLE
Bugfix: Enable attr_filter module before service's boost

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,8 +191,9 @@ class freeradius (
     notify  => Service[$freeradius::fr_service],
   }
   file { "${freeradius::fr_modulepath}/attr_filter":
-    ensure => link,
-    target => '../mods-available/attr_filter',
+    ensure  => link,
+    target  => '../mods-available/attr_filter',
+    notify  => Service[$freeradius::fr_service],
   }
 
   # Install default attribute filters


### PR DESCRIPTION
This pull request fixes a problematic situation when the `attr_file` module is enabled after the start of the corresponding service.

You can see the erroneous order in the following snippet.

```
Notice: /Stage[main]/Freeradius/Service[freeradius]/ensure: ensure changed 'stopped' to 'running'
Notice: /Stage[main]/Freeradius/File[/etc/freeradius/3.0/mods-enabled/attr_filter]/ensure: created
```