### PR TITLE
Next version of Debian is 10

### DIFF
--- a/manifests/module/eap.pp
+++ b/manifests/module/eap.pp
@@ -36,6 +36,8 @@ define freeradius::module::eap (
   Optional[String] $tls_check_cert_cn                               = undef,
   String $tls_cipher_list                                           = 'DEFAULT',
   Optional[Freeradius::Boolean] $tls_disable_tlsv1_2                = undef,
+  Optional[String] $tls_min_version                                 = undef,
+  Optional[String] $tls_max_version                                 = undef,
   String $tls_ecdh_curve                                            = 'prime256v1',
   Freeradius::Boolean $tls_cache_enable                             = 'yes',
   Integer $tls_cache_lifetime                                       = 24,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -86,14 +86,18 @@ class freeradius::params {
     }
     'Debian': {
       $fr_basepath = $::operatingsystemmajrelease ? {
-        '9'     => '/etc/freeradius/3.0',
-        '18.04'     => '/etc/freeradius/3.0',
-        default => '/etc/freeradius',
+        '9'          => '/etc/freeradius/3.0',
+        '10'         => '/etc/freeradius/3.0',
+        'buster/sid' => '/etc/freeradius/3.0',
+        '18.04'      => '/etc/freeradius/3.0',
+        default      => '/etc/freeradius',
       }
       $fr_raddbdir = $::operatingsystemmajrelease ? {
-        '9'     => "\${sysconfdir}/freeradius/3.0",
-        '18.04'     => "\${sysconfdir}/freeradius/3.0",
-        default => "\${sysconfdir}/freeradius",
+        '9'          => "\${sysconfdir}/freeradius/3.0",
+        '10'         => '\${sysconfdir}/freeradius/3.0',
+        'buster/sid' => '\${sysconfdir}/freeradius/3.0',
+        '18.04'      => "\${sysconfdir}/freeradius/3.0",
+        default      => "\${sysconfdir}/freeradius",
       }
     }
     default: {

--- a/templates/eap.erb
+++ b/templates/eap.erb
@@ -381,7 +381,27 @@ eap {
     disable_tlsv1_2 = <%= @tls_disable_tlsv1_2 %>
 <%- end -%>
 
+<%- if @tls_min_version or @tls_max_version -%>
+    #  Set min / max TLS version.  Mainly for Debian
+    #  "trusty", which disables older versions of TLS, and
+    #  requires the application to manually enable them.
     #
+    #  If you are running Debian trusty, you should set
+    #  these options, otherwise older clients will not be
+    #  able to connect.
+    #
+    #  Allowed values are "1.0", "1.1", and "1.2".
+    #
+    #  The values must be in quotes.
+    #
+<%- end -%>
+
+<%- if @tls_min_version -%>
+    tls_min_version = "<%= @tls_min_version -%>"
+<%- end -%>
+<%- if @tls_max_version -%>
+    tls_max_version = "<%= @tls_max_version -%>"
+<%- end -%>
 
     #
     #  Elliptical cryptography configuration


### PR DESCRIPTION
Still in testing (but frozen), on Debian Buster actually the fact 'operatingsystemmajrelease' resolves to 'buster/sid'