### PR TITLE
module file notifies service, not only symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 pkg/
 spec/fixures/
 .gemfile.lock
+Gemfile.lock
+/spec/fixtures/manifests/
+/spec/fixtures/modules/
+.ruby-gemset
+.ruby-version

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -33,6 +33,7 @@ define freeradius::module (
       source  => $source,
       content => $content,
       require => [Package[$fr_package], Group[$fr_group]],
+      notify  => Service[$fr_service],
     }
     file { "${fr_modulepath}/${name}":
       ensure  => $ensure_link,


### PR DESCRIPTION
now, if module file is updated, service is not notified since notify is only set on the symlink, which obviously stays the same. So just added notify to base module file