### PR TITLE
Fix for client iptables rules being repeatedly added by subsequent Puppet runs

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -58,14 +58,14 @@ define freeradius::client (
   if ($firewall and $ensure == 'present') {
     if $port {
       if $ip {
-        firewall { "100-${shortname}-${port}-v4":
+        firewall { "100 ${shortname} ${port} v4":
           proto  => 'udp',
           dport  => $port,
           action => 'accept',
           source => $ip,
         }
       } elsif $ip6 {
-        firewall { "100-${shortname}-${port}-v6":
+        firewall { "100 ${shortname} ${port} v6":
           proto    => 'udp',
           dport    => $port,
           action   => 'accept',


### PR DESCRIPTION
Removed hypens from firewall resources within client.pp to stop iptables rules being repeatedly added by subequent Puppet runs. Fixes #121 