### PR TITLE
Two fixes

### DIFF
--- a/manifests/module/files.pp
+++ b/manifests/module/files.pp
@@ -10,7 +10,7 @@ define freeradius::module::files (
   Optional[String] $usersfile          = undef,
   Optional[String] $acctusersfile      = undef,
   Optional[String] $preproxy_usersfile = undef,
-  Array[Hash] $users                   = [],
+  Array $users                         = [],
   Optional[String] $source             = undef,
   Optional[String] $content            = undef,
 ) {

--- a/templates/eap.erb
+++ b/templates/eap.erb
@@ -543,7 +543,7 @@ eap {
       tmpdir = <%= @tls_tmpdir %>
 <%- end -%>
 
-<%- if @tls_client -%>
+<%- if @tls_verify_client -%>
       #  The command used to verify the client cert.
       #  We recommend using the OpenSSL command-line
       #  tool.
@@ -556,7 +556,7 @@ eap {
       #  in PEM format.  This file is automatically
       #  deleted by the server when the command
       #  returns.
-      client = "<%= @tls_client %>"
+      client = "<%= @tls_verify_client %>"
 <%- end -%>
     }
 

--- a/templates/users.erb
+++ b/templates/users.erb
@@ -6,8 +6,8 @@
     <%- replies = user['reply_items'] ? user['reply_items'] : [] -%>
 <%= user['login'] %> <%= checks.join(", ") %>
 <%= "\t" + replies.join(",\n\t") %>
+
   <%- else -%>
 <%= user %>
   <%- end -%>
-
 <%- end -%>


### PR DESCRIPTION
Fix mismatch between tls_verify_client parameter in the eap module manifest and tls_client in the eap template
Fix users template permits the users array to contain either Hashes or Strings but the files module users parameter definition specifies it can only contain Hashes