### PR TITLE
Removed LDAP name

### DIFF
--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -5,7 +5,7 @@
 #
 #  Lightweight Directory Access Protocol (LDAP)
 #
-ldap <%= @name %> {
+ldap {
 	#  Note that this needs to match the name(s) in the LDAP server
 	#  certificate, if you're using ldaps.  See OpenLDAP documentation
 	#  for the behavioral semantics of specifying more than one host.


### PR DESCRIPTION
Fixes #118 . Just removing the name was enough to make it work. We have been running the modified code for some time now (the fork is published in our own private forge) and it works fine. It would be nice if this fix could be merged and a new version could be published to the public forge so we can use that version once again.