### PR TITLE
Create ippool files in freerad::module::ippool

### DIFF
--- a/manifests/module/ippool.pp
+++ b/manifests/module/ippool.pp
@@ -17,4 +17,25 @@ define freeradius::module::ippool (
     ensure  => $ensure,
     content => template('freeradius/ippool.erb'),
   }
+
+  $_file_path = $filename =~ Stdlib::AbsolutePath ? {
+    true    => $filename,
+    default => regsubst($filename, /\${db_dir}/, $freeradius::params::fr_basepath),
+  }
+  $_index_path = $ip_index =~ Stdlib::AbsolutePath ? {
+    true    => $ip_index,
+    default => regsubst($ip_index, /\${db_dir}/, $freeradius::params::fr_basepath),
+  }
+  file {$_file_path:
+    ensure => 'present',
+    owner  => $freeradius::params::fr_user,
+    group  => $freeradius::params::fr_group,
+    mode   => '0640',
+  }
+  file {$_index_path:
+    ensure => 'present',
+    owner  => $freeradius::params::fr_user,
+    group  => $freeradius::params::fr_group,
+    mode   => '0640',
+  }
 }


### PR DESCRIPTION
When defining an `freerad::module::ippool` this declaration also create
needed files.

These files could be created when freeradius starts, but in many cases the freeradius user doesn't have write permissiones in the freeradius directory (that is owned by root).

This patch creates these files from puppet.