### PR TITLE
Fix parameters checks in various definitions:

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -4,10 +4,10 @@ define freeradius::client (
   Optional[String] $shortname                        = $title,
   Optional[String] $ip                               = undef,
   Optional[String] $ip6                              = undef,
-  Enum['*', 'udp', 'tcp'] $proto                     = '*',
+  Optional[Enum['*', 'udp', 'tcp']] $proto           = '*',
   Freeradius::Boolean $require_message_authenticator = 'no',
   Optional[String] $virtual_server                   = undef,
-  Enum['cisco', 'computone', 'livingston', 'juniper', 'max40xx', 'multitech', 'netserver', 'pathras', 'patton', 'portslave', 'tc', 'usrhiper', 'other'] $nastype = undef,
+  Optional[Enum['cisco', 'computone', 'livingston', 'juniper', 'max40xx', 'multitech', 'netserver', 'pathras', 'patton', 'portslave', 'tc', 'usrhiper', 'other']] $nastype = undef,
   Optional[String] $login                            = undef,
   Optional[String] $password                         = undef,
   Optional[String] $coa_server                       = undef,
@@ -20,8 +20,8 @@ define freeradius::client (
   Optional[String] $srcip                            = undef,
   Boolean $firewall                                  = false,
   Freeradius::Ensure $ensure                         = present,
-  Array $attributes                    = [],
-  Optional[String] $huntgroups                    = undef,
+  Variant[Array, Hash, String] $attributes           = [],
+  Optional[String] $huntgroups                       = undef,
 ) {
   $fr_package  = $::freeradius::params::fr_package
   $fr_service  = $::freeradius::params::fr_service

--- a/manifests/home_server_pool.pp
+++ b/manifests/home_server_pool.pp
@@ -1,6 +1,6 @@
 # Configure home server pools
 define freeradius::home_server_pool (
-  String $home_server,
+  Variant[String, Array[String]] $home_server,
   Enum['fail-over', 'load-balance', 'client-balance', 'client-port-balance', 'keyed-balance'] $type = 'fail-over',
   Optional[String] $virtual_server = undef,
   Optional[String] $fallback       = undef,

--- a/manifests/huntgroup.pp
+++ b/manifests/huntgroup.pp
@@ -1,9 +1,9 @@
 # Install FreeRADIUS huntgroups
 define freeradius::huntgroup (
-  Freeradius::Ensure $ensure          = present,
-  Optional[String] $huntgroup         = $title,
-  Optional[Array[String]] $conditions = [],
-  Optional[Integer] $order            = 50,
+  Freeradius::Ensure $ensure                = present,
+  Optional[String] $huntgroup               = $title,
+  Optional[Array[String]] $conditions       = [],
+  Optional[Variant[String, Integer]] $order = 50,
 ) {
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_service  = $::freeradius::params::fr_service

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -6,7 +6,7 @@ define freeradius::listen (
   Optional[String] $ip                                      = undef,
   Optional[String] $ip6                                     = undef,
   Integer $port                                             = 0,
-  String $interface                                         = undef,
+  Optional[String] $interface                               = undef,
   Array[String] $clients                                    = [],
   Integer $max_connections                                  = 16,
   Integer $lifetime                                         = 0,

--- a/manifests/sql.pp
+++ b/manifests/sql.pp
@@ -31,7 +31,7 @@ define freeradius::sql (
   Optional[Integer] $pool_min                    = 1,
   Optional[Integer] $pool_spare                  = 1,
   Optional[Integer] $pool_idle_timeout           = 60,
-  Optional[Float] $pool_connect_timeout          = '3.0',
+  Optional[Float] $pool_connect_timeout          = 3.0,
 ) {
   $fr_package          = $::freeradius::params::fr_package
   $fr_service          = $::freeradius::params::fr_service


### PR DESCRIPTION
* `freeradius::client`:
  * `nastype` and `proto` are optional parameters
  * `attributes` could also be a hash or a string
* `freeradius::listen`:
  * `interface` parameter is optional
* `freeradius::home_server_pool`:
  * `home_server` parameter could be an array of strings too
* `freeradius::sql`:
  * pool_connect_timeout default value must be a float, not a string
* `freeradius::huntgroup`
  * Parameter `order` is used in `concat::fragment` which accepts
  strings or integer