### PR TITLE
quote ldap password

### DIFF
--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -30,7 +30,7 @@ ldap <%= @name %> {
 	identity = '<%= @identity %>'
 <%- end -%>
 <%- if @password -%>
-	password = <%= @password %>
+	password = '<%= @password %>'
 <%- end -%>
 
 	#  Unless overridden in another section, the dn from which all


### PR DESCRIPTION
In the current LDAP template, `identity` is quoted, but `password` is not.

```erb
<%- if @identity -%>
        identity = '<%= @identity %>'
<%- end -%>
<%- if @password -%>
        password = <%= @password %>
<%- end -%>
```

This PR makes them both (single) quoted.