### PR TITLE
parameterize syslog_facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Add the radius user to the winbind privileged group. You must install winbind se
 ##### `log_destination`
 Configure destination of log messages. Valid values are `files`, `syslog`, `stdout` and `stderr`. Default: `files`.
 
+##### `syslog_facility`
+Configure which syslog facility to use when `log_destination` is set to `syslog`. Default: `daemon`.
+
 ##### `syslog`
 Add a syslog rule (using the `saz/rsyslog` module). Default: `false`.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class freeradius (
   Boolean $winbind_support         = false,
   String $log_destination          = 'files',
   Boolean $syslog                  = false,
+  String $syslog_facility          = 'daemon',
   Freeradius::Boolean $log_auth    = 'no',
   Boolean $preserve_mods           = true,
   Boolean $correct_escapes         = true,

--- a/templates/radiusd.conf.erb
+++ b/templates/radiusd.conf.erb
@@ -327,7 +327,7 @@ log {
 	#  The exact values permitted here are OS-dependent.  You probably
 	#  don't want to change this.
 	#
-	syslog_facility = daemon
+	syslog_facility = <%= @syslog_facility %>
 
 	#  Log the full User-Name attribute, as it was found in the request.
 	#


### PR DESCRIPTION
We syslog to centralized syslog servers and separate different types of traffic by facility.   This was hardcoded to "daemon", so I added an optional parameter.