### PR TITLE
Set ownership for radacct and radius log dir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -354,7 +354,9 @@ class freeradius (
       $freeradius::fr_logpath,
       "${freeradius::fr_logpath}/radacct",
     ]:
+      group   => $freeradius::fr_group,
       mode    => '0750',
+      owner   => $freeradius::fr_user,
       require => Package[$freeradius::fr_package],
     }
 

--- a/spec/classes/freeradius_spec.rb
+++ b/spec/classes/freeradius_spec.rb
@@ -254,6 +254,8 @@ describe 'freeradius' do
           is_expected.to contain_file(file)
             .with(
               'mode'    => '0750',
+              'owner' => 'radiusd',
+              'group' => 'radiusd',
             )
             .that_requires('Package[freeradius]')
         end


### PR DESCRIPTION
If this module creates the radius log dirs, the owner and group is 'root' by default - so let's set it to the radius user.