### PR TITLE
Add quotes around expected LDAP password in freeradius::ldap spec

### DIFF
--- a/spec/defines/ldap_spec.rb
+++ b/spec/defines/ldap_spec.rb
@@ -25,7 +25,7 @@ describe 'freeradius::ldap' do
       .with_content(%r{^ldap test \{\n})
       .with_content(%r{^\s+server = 'localhost'\n})
       .with_content(%r{^\s+identity = 'cn=root,dc=example,dc=com'\n})
-      .with_content(%r{^\s+password = test password\n})
+      .with_content(%r{^\s+password = 'test password'\n})
       .with_content(%r{^\s+base_dn = 'dc=example,dc=com'\n})
       .with_ensure('present')
       .with_group('radiusd')


### PR DESCRIPTION
In 31a05c3 we put quotes around the LDAP password - but did not update the tests. This should sort that out.