### PR TITLE
Fix client attributes so that hashes and arrays work correctly

### DIFF
--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -45,13 +45,13 @@ client <%= @shortname %> {
 	}
 	<%- end -%>
 	<%- if defined?(@attributes) and !@attributes.empty? -%>
-		<%- if defined?(@attributes).respond_to?('join') -%>
+		<%- if @attributes.respond_to?('join') -%>
 	<%= @attributes.join("\n  ") %>
-		<%- elsif defined?(@attributes).is_a?(Hash) -%>
+		<%- elsif @attributes.is_a?(Hash) -%>
 			<%- @attributes.sort.each do |k, v| -%>
 	<%= k %> = <%= v %>
 			<%- end -%>
-		<%- elsif defined?(@attributes) -%>
+		<%- else -%>
 	<%= @attributes %>
 		<%- end -%>
 	<%- end -%>


### PR DESCRIPTION
In d2885da16c252658e31c17e91bd35df2f044d5d5 I was changing `if @var` to `if defined?(@var)` and accidentally changed:
```ruby
if @attributes.respond_to?('join')
```

to
```ruby
if defined?(@attributes).respond_to?('join')
```

which obviously doesn't work.

This commit reverts that, and doesn't check check `defined?(@attributes)` several times.