### PR TITLE
Allow client param $port to be an integer or an array

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -30,7 +30,7 @@ define freeradius::client (
   Optional[Integer] $lifetime                        = undef,
   Optional[Integer] $idle_timeout                    = undef,
   Optional[String] $redirect                         = undef,
-  Optional[Integer] $port                            = undef,
+  Optional[Variant[Integer,Array[Integer]]] $port    = undef,
   Optional[String] $srcip                            = undef,
   Boolean $firewall                                  = false,
   Freeradius::Ensure $ensure                         = present,
@@ -53,16 +53,22 @@ define freeradius::client (
   }
 
   if ($firewall and $ensure == 'present') {
+    if $port =~ Array {
+      $port_description = $port.join(',')
+    } else {
+      $port_description = $port
+    }
+
     if $port {
       if $ip {
-        firewall { "100 ${shortname} ${port} v4":
+        firewall { "100 ${shortname} ${port_description} v4":
           proto  => 'udp',
           dport  => $port,
           action => 'accept',
           source => $ip,
         }
       } elsif $ip6 {
-        firewall { "100 ${shortname} ${port} v6":
+        firewall { "100 ${shortname} ${port_description} v6":
           proto    => 'udp',
           dport    => $port,
           action   => 'accept',

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -61,4 +61,84 @@ describe 'freeradius::client' do
         .with_content(%r{^\s+password = "foo bar"$})
     end
   end
+
+  context 'with firewall' do
+    let(:params) do
+      super().merge(
+        firewall: true,
+
+    it do
+      is_expected.to compile.and_raise_error(%r{Must specify \$port if you specify \$firewall})
+    end
+
+    context 'with integer port' do
+      let(:params) do
+        super().merge(
+          port: 1234,
+        )
+      end
+
+      it do
+        is_expected.to contain_firewall('100 test_short 1234 v4')
+          .with_proto('udp')
+          .with_dport(1234)
+          .with_action('accept')
+          .with_source('1.2.3.4')
+      end
+
+      context 'with ipv6' do
+        let(:params) do
+          super().reject { |k, _| k == :ip }.merge(
+            ip6: '2001:db8::100',
+          )
+        end
+
+        it do
+          is_expected.not_to contain_firewall('100 test_short 1234 v4')
+
+          is_expected.to contain_firewall('100 test_short 1234 v6')
+            .with_proto('udp')
+            .with_dport(1234)
+            .with_action('accept')
+            .with_source('2001:db8::100')
+            .with_provider('ip6tables')
+        end
+      end
+    end
+
+    context 'with array port' do
+      let(:params) do
+        super().merge(
+          port: [1234, 4321],
+        )
+      end
+
+      it do
+        is_expected.to contain_firewall('100 test_short 1234,4321 v4')
+          .with_proto('udp')
+          .with_dport([1234, 4321])
+          .with_action('accept')
+          .with_source('1.2.3.4')
+      end
+
+      context 'with ipv6' do
+        let(:params) do
+          super().reject { |k, _| k == :ip }.merge(
+            ip6: '2001:db8::100',
+          )
+        end
+
+        it do
+          is_expected.not_to contain_firewall('100 test_short 1234,4321 v4')
+
+          is_expected.to contain_firewall('100 test_short 1234,4321 v6')
+            .with_proto('udp')
+            .with_dport([1234, 4321])
+            .with_action('accept')
+            .with_source('2001:db8::100')
+            .with_provider('ip6tables')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Add Array as an accepted type to `freeradius::client`
- Add testing for the firewall rules defined in `freeradius::client`.

Fixes #136 
