### PR TITLE
Sanity check secrets in freeradius::client

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,6 +1,6 @@
 # Install FreeRADIUS clients (WISMs or testing servers)
 define freeradius::client (
-  String $secret,
+  Freeradius::Secret $secret,
   Optional[String] $shortname                        = $title,
   Optional[String] $ip                               = undef,
   Optional[String] $ip6                              = undef,
@@ -23,7 +23,7 @@ define freeradius::client (
     'other',
   ]] $nastype = undef,
   Optional[String] $login                            = undef,
-  Optional[String] $password                         = undef,
+  Optional[Freeradius::Password] $password           = undef,
   Optional[String] $coa_server                       = undef,
   Optional[String] $response_window                  = undef,
   Optional[Integer] $max_connections                 = undef,
@@ -41,10 +41,6 @@ define freeradius::client (
   $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
-
-  if ($secret !~ /\A[^\n]+\z/) {
-    fail('Secrets cannot have newlines in them')
-  }
 
   file { "${fr_basepath}/clients.d/${shortname}.conf":
     ensure  => $ensure,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -42,6 +42,10 @@ define freeradius::client (
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
+  if ($secret !~ /\A[^\n]+\z/) {
+    fail('Secrets cannot have newlines in them')
+  }
+
   file { "${fr_basepath}/clients.d/${shortname}.conf":
     ensure  => $ensure,
     mode    => '0640',

--- a/manifests/home_server.pp
+++ b/manifests/home_server.pp
@@ -1,6 +1,6 @@
 # Configure a home_server for proxy config
 define freeradius::home_server (
-  String $secret,
+  Freeradius::Secret $secret,
   Enum['udp', 'tcp'] $proto                              = 'udp',
   Enum['none', 'status-server', 'request'] $status_check = 'none',
   Enum['auth', 'acct', 'auth+acct', 'coa'] $type         = 'auth',
@@ -11,7 +11,7 @@ define freeradius::home_server (
   Optional[Integer] $max_outstanding                     = undef,
   Optional[Enum['no', 'yes']] $no_response_fail          = undef,
   Optional[Integer] $num_answers_to_alive                = undef,
-  Optional[String] $password                             = undef,
+  Optional[Freeradius::Password] $password               = undef,
   Optional[Integer] $port                                = 1812,
   Optional[Integer] $response_window                     = undef,
   Optional[Integer] $revive_interval                     = undef,

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -1,7 +1,7 @@
 # Configure LDAP support for FreeRADIUS
 define freeradius::ldap (
   String $identity,
-  String $password,
+  Freeradius::Password $password,
   String $basedn,
   Array[String] $server         = ['localhost'],
   Integer $port                 = 389,

--- a/manifests/module/eap.pp
+++ b/manifests/module/eap.pp
@@ -17,7 +17,7 @@ define freeradius::module::eap (
   Optional[String] $gtc_challenge                                   = undef,
   String $gtc_auth_type                                             = 'PAP',
   String $tls_config_name                                           = 'tls-common',
-  Optional[String] $tls_private_key_password                        = undef,
+  Optional[Freeradius::Password] $tls_private_key_password          = undef,
   String $tls_private_key_file                                      = "\${certdir}/server.pem",
   String $tls_certificate_file                                      = "\${certdir}/server.pem",
   String $tls_ca_file                                               = "\${certdir}/ca.pem",

--- a/manifests/module/ldap.pp
+++ b/manifests/module/ldap.pp
@@ -5,7 +5,7 @@ define freeradius::module::ldap (
   Array[String] $server                                               = ['localhost'],
   Integer $port                                                       = 389,
   Optional[String] $identity                                          = undef,
-  Optional[String] $password                                          = undef,
+  Optional[Freeradius::Password] $password                            = undef,
   Optional[Freeradius::Sasl] $sasl                                    = {},
   Optional[String] $valuepair_attribute                               = undef,
   Optional[Array[String]] $update                                     = undef,

--- a/manifests/sql.pp
+++ b/manifests/sql.pp
@@ -1,7 +1,7 @@
 # Configure SQL support for FreeRADIUS
 define freeradius::sql (
   Enum['mysql', 'mssql', 'oracle', 'postgresql'] $database,
-  String $password,
+  Freeradius::Password $password,
   Optional[String] $server                       = 'localhost',
   Optional[String] $login                        = 'radius',
   Optional[String] $radius_db                    = 'radius',

--- a/manifests/statusclient.pp
+++ b/manifests/statusclient.pp
@@ -1,6 +1,6 @@
 # Install FreeRADIUS clients (WISMs or testing servers)
 define freeradius::statusclient (
-  String $secret,
+  Freeradius::Secret $secret,
   Optional[String] $ip        = undef,
   Optional[String] $ip6       = undef,
   Optional[Integer] $port     = undef,

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -24,4 +24,16 @@ describe 'freeradius::client' do
       .that_requires('File[/etc/raddb/clients.d]')
       .that_requires('Group[radiusd]')
   end
+
+  context 'with secret containing a newline' do
+    let(:params) do
+      super().merge(
+        secret: "foo\nbar",
+      )
+    end
+
+    it do
+      is_expected.to compile.and_raise_error(%r{Secrets cannot have newlines in them})
+    end
+  end
 end

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -33,7 +33,19 @@ describe 'freeradius::client' do
     end
 
     it do
-      is_expected.to compile.and_raise_error(%r{Secrets cannot have newlines in them})
+      is_expected.to compile.and_raise_error(%r{parameter 'secret' expects a match for Freeradius::Secret})
+    end
+  end
+
+  context 'with password containing a newline' do
+    let(:params) do
+      super().merge(
+        password: "foo\nbar",
+      )
+    end
+
+    it do
+      is_expected.to compile.and_raise_error(%r{parameter 'password' expects a match for Freeradius::Password})
     end
   end
 end

--- a/spec/defines/home_server_spec.rb
+++ b/spec/defines/home_server_spec.rb
@@ -18,4 +18,28 @@ describe 'freeradius::home_server' do
       .with_order('10')
       .with_target('/etc/raddb/proxy.conf')
   end
+
+  context 'with secret containing a newline' do
+    let(:params) do
+      super().merge(
+        secret: "foo\nbar",
+      )
+    end
+
+    it do
+      is_expected.to compile.and_raise_error(%r{parameter 'secret' expects a match for Freeradius::Secret})
+    end
+  end
+
+  context 'with password containing a newline' do
+    let(:params) do
+      super().merge(
+        password: "foo\nbar",
+      )
+    end
+
+    it do
+      is_expected.to compile.and_raise_error(%r{parameter 'password' expects a match for Freeradius::Password})
+    end
+  end
 end

--- a/spec/defines/module/ldap_spec.rb
+++ b/spec/defines/module/ldap_spec.rb
@@ -134,4 +134,16 @@ describe 'freeradius::module::ldap' do
   #     is_expected.to compile.and_raise_error(%r{^The `use_referral_credentials` parameter requires FreeRADIUS 3.1.x})
   #   end
   # end
+
+  context 'with password containing a newline' do
+    let(:params) do
+      super().merge(
+        password: "foo\nbar",
+      )
+    end
+
+    it do
+      is_expected.to compile.and_raise_error(%r{parameter 'password' expects a match for Freeradius::Password})
+    end
+  end
 end

--- a/spec/defines/sql_spec.rb
+++ b/spec/defines/sql_spec.rb
@@ -133,6 +133,18 @@ describe 'freeradius::sql' do
       #     is_expected.to compile.and_raise_error(%r{^The `pool_connect_timeout` parameter requires FreeRADIUS 3.1.x})
       #   end
       # end
+
+      context 'with password containing a newline' do
+        let(:params) do
+          super().merge(
+            password: "foo\nbar",
+          )
+        end
+
+        it do
+          is_expected.to compile.and_raise_error(%r{parameter 'password' expects a match for Freeradius::Password})
+        end
+      end
     end
   end
 end

--- a/spec/defines/statusclient_spec.rb
+++ b/spec/defines/statusclient_spec.rb
@@ -24,4 +24,16 @@ describe 'freeradius::statusclient' do
       .that_requires('Group[radiusd]')
       .that_requires('File[/etc/raddb/clients.d]')
   end
+
+  context 'with secret containing a newline' do
+    let(:params) do
+      super().merge(
+        secret: "foo\nbar",
+      )
+    end
+
+    it do
+      is_expected.to compile.and_raise_error(%r{parameter 'secret' expects a match for Freeradius::Secret})
+    end
+  end
 end

--- a/types/password.pp
+++ b/types/password.pp
@@ -1,0 +1,1 @@
+type Freeradius::Password = Pattern[/\A[^\n]+\z/]

--- a/types/secret.pp
+++ b/types/secret.pp
@@ -1,0 +1,1 @@
+type Freeradius::Secret = Pattern[/\A[^\n]+\z/]


### PR DESCRIPTION
Clients can accept secrets with a newline as part of the string, which causes the RADIUS system to restart and.. fail to start, because the resulting config is something like:
```
secret = "foo
bar"
```

This PR implements a basic check which looks for a negative answer to "is this entire string not `\n` chars", and then raises an error. I've implemented the logic like this so we can add other "illegal" chars easily if we find them.