### PR TITLE
Use ensure_newline for concats fragments

### DIFF
--- a/manifests/dictionary.pp
+++ b/manifests/dictionary.pp
@@ -32,7 +32,7 @@ define freeradius::dictionary (
   if ($ensure == 'present') {
     concat::fragment { "dictionary.${name}":
       target  => "${fr_basepath}/dictionary",
-      content => "\$INCLUDE ${fr_basepath}/dictionary.d/dictionary.${name}\n",
+      content => "\$INCLUDE ${fr_basepath}/dictionary.d/dictionary.${name}",
       order   => $order,
       require => File["${fr_basepath}/dictionary.d/dictionary.${name}"],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,11 +147,12 @@ class freeradius (
   # Set up concat policy file, as there is only one global policy
   # We also add standard header and footer
   concat { "${freeradius::fr_basepath}/policy.conf":
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    mode    => '0640',
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+    owner          => 'root',
+    group          => $freeradius::fr_group,
+    mode           => '0640',
+    ensure_newline => true,
+    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
+    notify         => Service[$freeradius::fr_service],
   }
   concat::fragment { 'policy_header':
     target  => "${freeradius::fr_basepath}/policy.conf",
@@ -166,11 +167,12 @@ class freeradius (
 
   # Set up concat template file
   concat { "${freeradius::fr_basepath}/templates.conf":
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    mode    => '0640',
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+    owner          => 'root',
+    group          => $freeradius::fr_group,
+    mode           => '0640',
+    ensure_newline => true,
+    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
+    notify         => Service[$freeradius::fr_service],
   }
   concat::fragment { 'template_header':
     target => "${freeradius::fr_basepath}/templates.conf",
@@ -186,25 +188,27 @@ class freeradius (
 
   # Set up concat proxy file
   concat { "${freeradius::fr_basepath}/proxy.conf":
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    mode    => '0640',
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+    owner          => 'root',
+    group          => $freeradius::fr_group,
+    mode           => '0640',
+    ensure_newline => true,
+    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
+    notify         => Service[$freeradius::fr_service],
   }
   concat::fragment { 'proxy_header':
     target  => "${freeradius::fr_basepath}/proxy.conf",
-    content => "# Proxy config\n",
+    content => '# Proxy config',
     order   => '05',
   }
 
   # Set up attribute filter file
   concat { "${freeradius::fr_basepath}/mods-available/attr_filter":
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    mode    => '0640',
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+    owner          => 'root',
+    group          => $freeradius::fr_group,
+    mode           => '0640',
+    ensure_newline => true,
+    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
+    notify         => Service[$freeradius::fr_service],
   }
   file { "${freeradius::fr_modulepath}/attr_filter":
     ensure => link,
@@ -238,10 +242,11 @@ class freeradius (
   # Install a slightly tweaked stock dictionary that includes
   # our custom dictionaries
   concat { "${freeradius::fr_basepath}/dictionary":
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    mode    => '0644',
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
+    owner          => 'root',
+    group          => $freeradius::fr_group,
+    mode           => '0644',
+    ensure_newline => true,
+    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
   }
   concat::fragment { 'dictionary_header':
     target => "${freeradius::fr_basepath}/dictionary",
@@ -256,11 +261,12 @@ class freeradius (
 
   # Install a huntgroups file
   concat { "${freeradius::fr_basepath}/mods-config/preprocess/huntgroups":
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    mode    => '0640',
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+    owner          => 'root',
+    group          => $freeradius::fr_group,
+    mode           => '0640',
+    ensure_newline => true,
+    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
+    notify         => Service[$freeradius::fr_service],
   }
   concat::fragment { 'huntgroups_header':
     target => "${freeradius::fr_basepath}/mods-config/preprocess/huntgroups",
@@ -454,7 +460,7 @@ class freeradius (
     "${freeradius::fr_basepath}/clients.conf",
     "${freeradius::fr_basepath}/sql.conf",
   ]:
-    content => "# FILE INTENTIONALLY BLANK\n",
+    content => '# FILE INTENTIONALLY BLANK',
     mode    => '0644',
     owner   => 'root',
     group   => $freeradius::fr_group,

--- a/manifests/policy.pp
+++ b/manifests/policy.pp
@@ -25,7 +25,7 @@ define freeradius::policy (
   if ($ensure == 'present') {
     concat::fragment { "policy-${name}":
       target  => "${fr_basepath}/policy.conf",
-      content => "\t\$INCLUDE ${fr_basepath}/policy.d/${name}\n",
+      content => "\t\$INCLUDE ${fr_basepath}/policy.d/${name}",
       order   => $order,
       require => File["${fr_basepath}/policy.d/${name}"],
     }

--- a/spec/classes/freeradius_spec.rb
+++ b/spec/classes/freeradius_spec.rb
@@ -79,10 +79,11 @@ describe 'freeradius' do
       it do
         is_expected.to contain_concat('/etc/raddb/policy.conf')
           .with(
-            'group'   => 'radiusd',
-            'mode'    => '0640',
-            'notify'  => 'Service[radiusd]',
-            'owner'   => 'root',
+            'group'          => 'radiusd',
+            'mode'           => '0640',
+            'notify'         => 'Service[radiusd]',
+            'owner'          => 'root',
+            'ensure_newline' => true,
           )
           .that_requires('Package[freeradius]')
           .that_requires('Group[radiusd]')
@@ -109,10 +110,11 @@ describe 'freeradius' do
       it do
         is_expected.to contain_concat('/etc/raddb/proxy.conf')
           .with(
-            'group'   => 'radiusd',
-            'mode'    => '0640',
-            'notify'  => 'Service[radiusd]',
-            'owner'   => 'root',
+            'group'          => 'radiusd',
+            'mode'           => '0640',
+            'notify'         => 'Service[radiusd]',
+            'owner'          => 'root',
+            'ensure_newline' => true,
           )
           .that_requires('Package[freeradius]')
           .that_requires('Group[radiusd]')
@@ -121,7 +123,7 @@ describe 'freeradius' do
       it do
         is_expected.to contain_concat__fragment('proxy_header')
           .with(
-            'content' => "# Proxy config\n",
+            'content' => '# Proxy config',
             'order'   => '05',
             'target'  => '/etc/raddb/proxy.conf',
           )
@@ -130,10 +132,11 @@ describe 'freeradius' do
       it do
         is_expected.to contain_concat('/etc/raddb/mods-available/attr_filter')
           .with(
-            'group'   => 'radiusd',
-            'mode'    => '0640',
-            'notify'  => 'Service[radiusd]',
-            'owner'   => 'root',
+            'group'          => 'radiusd',
+            'mode'           => '0640',
+            'notify'         => 'Service[radiusd]',
+            'owner'          => 'root',
+            'ensure_newline' => true,
           )
           .that_requires('Package[freeradius]')
           .that_requires('Group[radiusd]')
@@ -150,9 +153,10 @@ describe 'freeradius' do
       it do
         is_expected.to contain_concat('/etc/raddb/dictionary')
           .with(
-            'group'   => 'radiusd',
-            'mode'    => '0644',
-            'owner'   => 'root',
+            'group'          => 'radiusd',
+            'mode'           => '0644',
+            'owner'          => 'root',
+            'ensure_newline' => true,
           )
           .that_requires('Package[freeradius]')
           .that_requires('Group[radiusd]')
@@ -364,7 +368,7 @@ describe 'freeradius' do
         ].each do |file|
           is_expected.to contain_file(file)
             .with(
-              'content' => "# FILE INTENTIONALLY BLANK\n",
+              'content' => '# FILE INTENTIONALLY BLANK',
               'group'   => 'radiusd',
               'mode'    => '0644',
               'notify'  => 'Service[radiusd]',

--- a/spec/defines/policy_spec.rb
+++ b/spec/defines/policy_spec.rb
@@ -25,7 +25,7 @@ describe 'freeradius::policy' do
 
   it do
     is_expected.to contain_concat__fragment('policy-test')
-      .with_content(%r{\s+\$INCLUDE /etc/raddb/policy.d/test\n})
+      .with_content(%r{\s+\$INCLUDE /etc/raddb/policy.d/test$})
       .with_order('50')
       .with_target('/etc/raddb/policy.conf')
       .that_requires('File[/etc/raddb/policy.d/test]')


### PR DESCRIPTION
We currently use `\n` at the end of concat fragments. Concat has an `ensure_newline` parameter which handles this for you, so we don't have to remember to add a newline at the end of each fragment.

This changes updates the concats to use this, and removes the manual `\n` from the end of fragments.

This parameter has been in concat since 1.0.0 so no version requirements change here (currently we require `>=1.0.0 <7.0.0`).