### PR TITLE
Fix capitalisation of PIDFile

### DIFF
--- a/spec/classes/radsniff_spec.rb
+++ b/spec/classes/radsniff_spec.rb
@@ -60,7 +60,7 @@ describe 'freeradius::radsniff' do
 
         it do
           is_expected.to contain_systemd__unit_file('radsniff.service')
-            .with_content(%r{^Pidfile=/var/run/radiusd/radsniff.pid$})
+            .with_content(%r{^PIDFile=/var/run/radiusd/radsniff.pid$})
             .with_content(%r{^EnvironmentFile=/etc/sysconfig/radsniff$})
             .with_content(%r{^ExecStart=/usr/bin/radsniff -P /var/run/radiusd/radsniff.pid -d /etc/raddb \$RADSNIFF_OPTIONS$})
             .that_notifies('Service[radsniff]')
@@ -75,7 +75,7 @@ describe 'freeradius::radsniff' do
 
         it do
           is_expected.to contain_systemd__unit_file('radsniff.service')
-            .with_content(%r{^Pidfile=/var/run/freeradius/radsniff.pid$})
+            .with_content(%r{^PIDFile=/var/run/freeradius/radsniff.pid$})
             .with_content(%r{^EnvironmentFile=/etc/defaults/radsniff$})
             .with_content(%r{^ExecStart=/usr/bin/radsniff -P /var/run/freeradius/radsniff.pid -d /etc/freeradius \$RADSNIFF_OPTIONS$})
             .that_notifies('Service[radsniff]')
@@ -112,7 +112,7 @@ describe 'freeradius::radsniff' do
 
         it do
           is_expected.to contain_systemd__unit_file('radsniff.service')
-            .with_content(%r{^Pidfile=/a/pid/file$})
+            .with_content(%r{^PIDFile=/a/pid/file$})
             .with_content(%r{^EnvironmentFile=/test/env/file$})
             .with_content(%r{^ExecStart=/usr/bin/radsniff -P /a/pid/file -d .* \$RADSNIFF_OPTIONS$})
             .that_notifies('Service[radsniff]')

--- a/templates/radsniff.service.erb
+++ b/templates/radsniff.service.erb
@@ -5,7 +5,7 @@ After=radiusd.target
 
 [Service]
 Type=forking
-Pidfile=<%=scope['::freeradius::radsniff::final_pidfile']%>
+PIDFile=<%=scope['::freeradius::radsniff::final_pidfile']%>
 EnvironmentFile=<%=scope['::freeradius::radsniff::final_envfile']%>
 ExecStart=/usr/bin/radsniff -P <%=scope['::freeradius::radsniff::final_pidfile']%> -d <%=scope['::freeradius::radsniff::fr_basepath']%> $RADSNIFF_OPTIONS
 


### PR DESCRIPTION
In #157 I added a systemd unit for radsniff, which had the PIDFile option as `Pidfile` which systemd errors on. It doesn't prevent it from running, but it does raise an error and likely doesn't work very well.

This PR fixes that capitalisation.