### PR TITLE
Wrap secrets and passwords in quotes

### DIFF
--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -48,4 +48,17 @@ describe 'freeradius::client' do
       is_expected.to compile.and_raise_error(%r{parameter 'password' expects a match for Freeradius::Password})
     end
   end
+
+  context 'with password' do
+    let(:params) do
+      super().merge(
+        password: "foo bar",
+      )
+    end
+
+    it do
+      is_expected.to contain_file('/etc/raddb/clients.d/test_short.conf')
+        .with_content(%r{^\s+password = "foo bar"$})
+    end
+  end
 end

--- a/spec/defines/home_server_spec.rb
+++ b/spec/defines/home_server_spec.rb
@@ -14,7 +14,7 @@ describe 'freeradius::home_server' do
 
   it do
     is_expected.to contain_concat__fragment('homeserver-test')
-      .with_content(%r{home_server test {\n\s+type = auth\n\s+ipaddr = 1.2.3.4\n\s+port = 1812\n\s+proto = udp\n\s+secret = test_secret\n\s+status_check = none\n}\n})
+      .with_content(%r{home_server test {\n\s+type = auth\n\s+ipaddr = 1.2.3.4\n\s+port = 1812\n\s+proto = udp\n\s+secret = "test_secret"\n\s+status_check = none\n}\n})
       .with_order('10')
       .with_target('/etc/raddb/proxy.conf')
   end

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -23,7 +23,7 @@ client <%= @shortname %> {
 	login = <%= @login %>
 	<%- end -%>
 	<%- if defined?(@password) -%>
-	password = <%= @password %>
+	password = "<%= @password %>"
 	<%- end -%>
 	<%- if defined?(@coa_server) -%>
 	coa_server = <%= @coa_server %>

--- a/templates/eap.erb
+++ b/templates/eap.erb
@@ -216,7 +216,7 @@ eap {
 #		private_key_password = whatever
 #		private_key_file = ${certdir}/server.pem
 <%- if @tls_private_key_password -%>
-		private_key_password = <%= @tls_private_key_password %>
+		private_key_password = "<%= @tls_private_key_password %>"
 <%- end -%>
 		private_key_file = <%= @tls_private_key_file %>
 		private_key_password = whatever

--- a/templates/home_server.erb
+++ b/templates/home_server.erb
@@ -11,7 +11,7 @@ home_server <%= @name %> {
 <% end -%>
     port = <%= @port %>
     proto = <%= @proto %>
-    secret = <%= @secret %>
+    secret = "<%= @secret %>"
 <% if defined?(@src_ipaddr) -%>
     src_ipaddr = <%= @src_ipaddr %>
 <% end -%>
@@ -34,7 +34,7 @@ home_server <%= @name %> {
     username = <%= @username %>
 <% end -%>
 <% if defined?(@password) -%>
-    password = <%= @password %>
+    password = "<%= @password %>"
 <% end -%>
 <% if defined?(@check_interval) -%>
     check_interval = <%= @check_interval %>


### PR DESCRIPTION
Secrets and passwords should be wrapped in quotes, to avoid issues with unusual chars.

This has been tested in my environment and is working fine.