### PR TITLE
Add virtual servers to listeners and add 'relaxed' option to attr_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ freeradius::attr { 'eduroamlocal':
 }
 ```
 
+##### `relaxed`
+Whether the filter removes or copies unmatched attributes, relaxed = no or yes respectively. An undefined value results in no
+explicit statement, causing the default behaviour of FreeRADIUS equivalent to 'relaxed = no'. Default: `undef`.
+
 #### `freeradius::blank`
 
 Selectively blank certain stock config files that aren't required. This is preferable to deleting them

--- a/manifests/attr.pp
+++ b/manifests/attr.pp
@@ -4,7 +4,7 @@ define freeradius::attr (
   Freeradius::Ensure $ensure           = present,
   Optional[String] $key                = 'User-Name',
   Optional[String] $prefix             = 'filter',
-  Optional[Enum['yes', 'no']] $relaxed = 'no',
+  Optional[Enum['yes', 'no']] $relaxed = undef,
 ) {
   $fr_package          = $::freeradius::params::fr_package
   $fr_service          = $::freeradius::params::fr_service

--- a/manifests/attr.pp
+++ b/manifests/attr.pp
@@ -1,10 +1,10 @@
 # Install FreeRADIUS config snippets
 define freeradius::attr (
   String $source,
-  Freeradius::Ensure $ensure           = present,
-  Optional[String] $key                = 'User-Name',
-  Optional[String] $prefix             = 'filter',
-  Optional[Enum['yes', 'no']] $relaxed = undef,
+  Freeradius::Ensure $ensure             = present,
+  Optional[String] $key                  = 'User-Name',
+  Optional[String] $prefix               = 'filter',
+  Optional[Freeradius::Boolean] $relaxed = undef,
 ) {
   $fr_package          = $::freeradius::params::fr_package
   $fr_service          = $::freeradius::params::fr_service

--- a/manifests/attr.pp
+++ b/manifests/attr.pp
@@ -1,9 +1,10 @@
 # Install FreeRADIUS config snippets
 define freeradius::attr (
   String $source,
-  Freeradius::Ensure $ensure = present,
-  Optional[String] $key      = 'User-Name',
-  Optional[String] $prefix   = 'filter',
+  Freeradius::Ensure $ensure           = present,
+  Optional[String] $key                = 'User-Name',
+  Optional[String] $prefix             = 'filter',
+  Optional[Enum['yes', 'no']] $relaxed = 'no',
 ) {
   $fr_package          = $::freeradius::params::fr_package
   $fr_service          = $::freeradius::params::fr_service

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -7,6 +7,7 @@ define freeradius::listen (
   Optional[String] $ip6                                     = undef,
   Integer $port                                             = 0,
   Optional[String] $interface                               = undef,
+  Optional[String] $virtual_server                          = undef,
   Array[String] $clients                                    = [],
   Integer $max_connections                                  = 16,
   Integer $lifetime                                         = 0,

--- a/spec/defines/attr_spec.rb
+++ b/spec/defines/attr_spec.rb
@@ -5,86 +5,51 @@ describe 'freeradius::attr' do
 
   let(:title) { 'test' }
 
-  context 'No specific relaxed value' do
-    let(:params) do
-      {
-        source: 'puppet:///modules/test/path/to/file',
-      }
-    end
+  let(:params) do
+    {
+      source: 'puppet:///modules/test/path/to/file',
+    }
+  end
 
-    it do
-      is_expected.to contain_file('/etc/raddb/mods-config/attr_filter/test')
-        .that_notifies('Service[radiusd]')
-        .that_requires('Group[radiusd]')
-        .that_requires('Package[freeradius]')
-        .with_ensure('present')
-        .with_group('radiusd')
-        .with_mode('0640')
-        .with_owner('root')
-        .with_source('puppet:///modules/test/path/to/file')
+  it do
+    is_expected.to contain_file('/etc/raddb/mods-config/attr_filter/test')
+      .that_notifies('Service[radiusd]')
+      .that_requires('Group[radiusd]')
+      .that_requires('Package[freeradius]')
+      .with_ensure('present')
+      .with_group('radiusd')
+      .with_mode('0640')
+      .with_owner('root')
+      .with_source('puppet:///modules/test/path/to/file')
+  end
+
+  it do
+    is_expected.to contain_concat__fragment('attr-test')
+      .with_content(%r{^attr_filter filter.test {\n\s+key = "\%{User-Name}"\n\s+filename = \${modconfdir}/\${\.:name}/test\n}})
+      .without_content(%r{^\s+relaxed\s+.*$})
+      .with_order('20')
+      .with_target('/etc/raddb/mods-available/attr_filter')
+  end
+
+  context 'with relaxed = no' do
+    let(:params) do
+      super().merge(relaxed: 'no')
     end
 
     it do
       is_expected.to contain_concat__fragment('attr-test')
-        .with_content(%r{^attr_filter filter.test {\n\s+key = "\%{User-Name}"\n\s+filename = \${modconfdir}/\${\.:name}/test\n}})
-        .with_order('20')
-        .with_target('/etc/raddb/mods-available/attr_filter')
+        .with_content(%r{^\s+relaxed\s+=\s+no$})
     end
   end
 
-  context 'relaxed = no' do
+  context 'with relaxed = yes' do
     let(:params) do
-      {
-        source: 'puppet:///modules/test/path/to/file',
-        relaxed: 'no',
-      }
-    end
-
-    it do
-      is_expected.to contain_file('/etc/raddb/mods-config/attr_filter/test')
-        .that_notifies('Service[radiusd]')
-        .that_requires('Group[radiusd]')
-        .that_requires('Package[freeradius]')
-        .with_ensure('present')
-        .with_group('radiusd')
-        .with_mode('0640')
-        .with_owner('root')
-        .with_source('puppet:///modules/test/path/to/file')
+      super().merge(relaxed: 'yes')
     end
 
     it do
       is_expected.to contain_concat__fragment('attr-test')
-        .with_content(%r{^attr_filter filter.test {\n\s+key = "\%{User-Name}"\n\s+filename = \${modconfdir}/\${\.:name}/test\n\s+relaxed = no\n}})
-        .with_order('20')
-        .with_target('/etc/raddb/mods-available/attr_filter')
-    end
-  end
-
-  context 'relaxed = yes' do
-    let(:params) do
-      {
-        source: 'puppet:///modules/test/path/to/file',
-        relaxed: 'yes',
-      }
-    end
-
-    it do
-      is_expected.to contain_file('/etc/raddb/mods-config/attr_filter/test')
-        .that_notifies('Service[radiusd]')
-        .that_requires('Group[radiusd]')
-        .that_requires('Package[freeradius]')
-        .with_ensure('present')
-        .with_group('radiusd')
-        .with_mode('0640')
-        .with_owner('root')
-        .with_source('puppet:///modules/test/path/to/file')
-    end
-
-    it do
-      is_expected.to contain_concat__fragment('attr-test')
-        .with_content(%r{^attr_filter filter.test {\n\s+key = "\%{User-Name}"\n\s+filename = \${modconfdir}/\${\.:name}/test\n\s+relaxed = yes\n}})
-        .with_order('20')
-        .with_target('/etc/raddb/mods-available/attr_filter')
+        .with_content(%r{^\s+relaxed\s+=\s+yes$})
     end
   end
 end

--- a/spec/defines/attr_spec.rb
+++ b/spec/defines/attr_spec.rb
@@ -5,28 +5,86 @@ describe 'freeradius::attr' do
 
   let(:title) { 'test' }
 
-  let(:params) do
-    {
-      source: 'puppet:///modules/test/path/to/file',
-    }
+  context 'No specific relaxed value' do
+    let(:params) do
+      {
+        source: 'puppet:///modules/test/path/to/file',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('/etc/raddb/mods-config/attr_filter/test')
+        .that_notifies('Service[radiusd]')
+        .that_requires('Group[radiusd]')
+        .that_requires('Package[freeradius]')
+        .with_ensure('present')
+        .with_group('radiusd')
+        .with_mode('0640')
+        .with_owner('root')
+        .with_source('puppet:///modules/test/path/to/file')
+    end
+
+    it do
+      is_expected.to contain_concat__fragment('attr-test')
+        .with_content(%r{^attr_filter filter.test {\n\s+key = "\%{User-Name}"\n\s+filename = \${modconfdir}/\${\.:name}/test\n}})
+        .with_order('20')
+        .with_target('/etc/raddb/mods-available/attr_filter')
+    end
   end
 
-  it do
-    is_expected.to contain_file('/etc/raddb/mods-config/attr_filter/test')
-      .that_notifies('Service[radiusd]')
-      .that_requires('Group[radiusd]')
-      .that_requires('Package[freeradius]')
-      .with_ensure('present')
-      .with_group('radiusd')
-      .with_mode('0640')
-      .with_owner('root')
-      .with_source('puppet:///modules/test/path/to/file')
+  context 'relaxed = no' do
+    let(:params) do
+      {
+        source: 'puppet:///modules/test/path/to/file',
+        relaxed: 'no',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('/etc/raddb/mods-config/attr_filter/test')
+        .that_notifies('Service[radiusd]')
+        .that_requires('Group[radiusd]')
+        .that_requires('Package[freeradius]')
+        .with_ensure('present')
+        .with_group('radiusd')
+        .with_mode('0640')
+        .with_owner('root')
+        .with_source('puppet:///modules/test/path/to/file')
+    end
+
+    it do
+      is_expected.to contain_concat__fragment('attr-test')
+        .with_content(%r{^attr_filter filter.test {\n\s+key = "\%{User-Name}"\n\s+filename = \${modconfdir}/\${\.:name}/test\n\s+relaxed = no\n}})
+        .with_order('20')
+        .with_target('/etc/raddb/mods-available/attr_filter')
+    end
   end
 
-  it do
-    is_expected.to contain_concat__fragment('attr-test')
-      .with_content(%r{^attr_filter filter.test {\n\s+key = "\%{User-Name}"\n\s+filename = \${modconfdir}/\${\.:name}/test\n}})
-      .with_order('20')
-      .with_target('/etc/raddb/mods-available/attr_filter')
+  context 'relaxed = yes' do
+    let(:params) do
+      {
+        source: 'puppet:///modules/test/path/to/file',
+        relaxed: 'yes',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('/etc/raddb/mods-config/attr_filter/test')
+        .that_notifies('Service[radiusd]')
+        .that_requires('Group[radiusd]')
+        .that_requires('Package[freeradius]')
+        .with_ensure('present')
+        .with_group('radiusd')
+        .with_mode('0640')
+        .with_owner('root')
+        .with_source('puppet:///modules/test/path/to/file')
+    end
+
+    it do
+      is_expected.to contain_concat__fragment('attr-test')
+        .with_content(%r{^attr_filter filter.test {\n\s+key = "\%{User-Name}"\n\s+filename = \${modconfdir}/\${\.:name}/test\n\s+relaxed = yes\n}})
+        .with_order('20')
+        .with_target('/etc/raddb/mods-available/attr_filter')
+    end
   end
 end

--- a/templates/attr.erb
+++ b/templates/attr.erb
@@ -1,6 +1,8 @@
 attr_filter <%= @prefix %>.<%= @name %> {
 	key = "%{<%= @key %>}"
 	filename = ${modconfdir}/${.:name}/<%= @name %>
+<% if defined?(@relaxed) -%>
 	relaxed = <%= @relaxed %>
+<% end -%>
 }
 

--- a/templates/attr.erb
+++ b/templates/attr.erb
@@ -1,5 +1,6 @@
 attr_filter <%= @prefix %>.<%= @name %> {
 	key = "%{<%= @key %>}"
 	filename = ${modconfdir}/${.:name}/<%= @name %>
+	relaxed = <%= @relaxed %>
 }
 

--- a/templates/listen.erb
+++ b/templates/listen.erb
@@ -90,6 +90,12 @@ listen {
 	interface = <%= @interface %>
 <%- end -%>
 
+<%- if @virtual_server -%>
+	#  Configure the virtual server to send traffic from this listener to.
+	#
+	virtual_server = <%= @virtual_server %>
+<%- end -%>
+
 	#  Per-socket lists of clients.  This is a very useful feature.
 	#
 	#  The name here is a reference to a section elsewhere in


### PR DESCRIPTION
Add the 'virtual_server = ...' statement to listeners, for servers with multiple listeners.

Add the 'relaxed = ...' statement to the attribute filter, to allow for pass-through style filtering.