### PR TITLE
add Rocky to list of Redhat-dists

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class freeradius::params {
         5       => '2',
         6       => '2',
         7       => '3',
+        8       => '3',
         default => '3',
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@ class freeradius::params {
 
   # Make an educated guess which version of FR we are running, based on the OS
   case $::operatingsystem {
-    /RedHat|CentOS/: {
+    /RedHat|CentOS|Rocky/: {
       $fr_guessversion = $::operatingsystemmajrelease ? {
         5       => '2',
         6       => '2',

--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,21 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
       ]
     },
     {


### PR DESCRIPTION
Add Rocky to the list of Redhat-distributions to allow usage on a freshly installed Rocky-system.