### PR TITLE
Fix typo in freeradius::client spec

### DIFF
--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -66,6 +66,8 @@ describe 'freeradius::client' do
     let(:params) do
       super().merge(
         firewall: true,
+      )
+    end
 
     it do
       is_expected.to compile.and_raise_error(%r{Must specify \$port if you specify \$firewall})


### PR DESCRIPTION
In #160 I added specs for the freeradius::client define, which had a bad typo in them - not closing off the `let(:params)` block. This fixes that so that all tests pass.