### PR TITLE
Add github workflow to run PDK tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Build and publish to Puppet Forge
+
+on:
+ push:
+  tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get latest tag
+      id: vars
+      run: echo ::set-output name=tag::${GITHUB_REF:10}
+    - name: Clone repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ steps.vars.outputs.tag }}
+    - name: Build and publish module
+      uses: barnumbirr/action-forge-publish@v2.8.0
+      env:
+       FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
+       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Run PDK tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+
+    - name: Run unit tests
+      uses: puppets-epic-show-theatre/action-pdk-test-unit@v1
+      with:
+        puppet-version: ""
+        # [optional]
+        # A string indicating the Puppet version to validate against, such as "5.4.2" or "5.5".
+        pe-version: ""
+        # [optional]
+        # A string indicating the PE version to validate against, such as "2017.3.5" or "2018.1".
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+
+    - name: Run PDK validate
+      uses: puppets-epic-show-theatre/action-pdk-validate@v1
+      with:
+        puppet-version: ""
+        # [optional]
+        # A string indicating the Puppet version to validate against, such as "5.4.2" or "5.5".
+        pe-version: ""
+        # [optional]
+        # A string indicating the PE version to validate against, such as "2017.3.5" or "2018.1".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 3.9.2
+  * Bugfix: Restart FreeRADIUS after any huntgroups modification
+
 ### 3.9.1
   * Various bugfixes in parameter type validation (thanks @craigwatson and @amateo)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+This module was written primarily for internal use - features we haven't needed to
+use probably haven't been written. Please send pull requests with new features and
+bug fixes. You are also welcome to file issues but I make no guarantees of
+development effort if the features aren't useful to my employer.
+
+This module uses Github Actions for testing and validation. Any contributions
+must pass tests cleanly, so please ensure you update the tests to match your
+contribution.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@
        * [`freeradius::template`](#freeradiustemplate)
        * [`freeradius::virtual_module`](#freeradiusvirtual_module)
 4. [Limitations - OS compatibility, etc.](#limitations)
-5. [Development - Guide for contributing to the module](#development)
 
 ## Overview
 
@@ -1625,10 +1624,3 @@ might work. Likely sticking points with other distros are the names of packages,
 services and file paths.
 
 This module requires Puppet 4 or greater.
-
-## Development
-
-This module was written primarily for internal use - features we haven't needed to
-use probably haven't been written. Please send pull requests with new features and
-bug fixes. You are also welcome to file issues but I make no guarantees of
-development effort if the features aren't useful to my employer.

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -52,7 +52,7 @@ describe 'freeradius::client' do
   context 'with password' do
     let(:params) do
       super().merge(
-        password: "foo bar",
+        password: 'foo bar',
       )
     end
 


### PR DESCRIPTION
Create a GitHub workflow which runs PDK tests - just using the workflow example from https://github.com/mysociety/action-pdk for now.
This workflow currently fails because of the issue that will be fixed in #174.

Github actions is good - there are other options available, but this is super low effort to make go. If we find it lacking we can look at others - but I think if we look at using GH Actions for doing releases then it's reasonable to use it for testing, too.