### PR TITLE
Debian 11 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -93,6 +93,7 @@ class freeradius::params {
       $fr_basepath = $::operatingsystemmajrelease ? {
         '9'          => '/etc/freeradius/3.0',
         '10'         => '/etc/freeradius/3.0',
+        '11'         => '/etc/freeradius/3.0',
         'buster/sid' => '/etc/freeradius/3.0',
         '18.04'      => '/etc/freeradius/3.0',
         '20.04'      => '/etc/freeradius/3.0',
@@ -101,6 +102,7 @@ class freeradius::params {
       $fr_raddbdir = $::operatingsystemmajrelease ? {
         '9'          => "\${sysconfdir}/freeradius/3.0",
         '10'         => "\${sysconfdir}/freeradius/3.0",
+        '11'         => "\${sysconfdir}/freeradius/3.0",
         'buster/sid' => "\${sysconfdir}/freeradius/3.0",
         '18.04'      => "\${sysconfdir}/freeradius/3.0",
         '20.04'      => "\${sysconfdir}/freeradius/3.0",


### PR DESCRIPTION
Even though it is FreeRadius 3.2, still the directory "3.0" is used by systemd service