### PR TITLE
add support for EL9 (RedHat, Rocky and AlmaLinux)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,12 +2,13 @@
 class freeradius::params {
   # Make an educated guess which version of FR we are running, based on the OS
   case $::operatingsystem {
-    /RedHat|CentOS|Rocky/: {
+    /RedHat|CentOS|Rocky|AlmaLinux/: {
       $fr_guessversion = $::operatingsystemmajrelease ? {
         5       => '2',
         6       => '2',
         7       => '3',
         8       => '3',
+        9       => '3',
         default => '3',
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -38,20 +38,30 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
This PR will add support for EL9 and also include AlmaLinux in the process.

Please note that CI is currently failing (which I fixed in PR #181). I can rebase once that other PR got merged.