### PR TITLE
Rework resources to have OS-independent names

### DIFF
--- a/manifests/attr.pp
+++ b/manifests/attr.pp
@@ -6,27 +6,24 @@ define freeradius::attr (
   Optional[String] $prefix               = 'filter',
   Optional[Freeradius::Boolean] $relaxed = undef,
 ) {
-  $fr_package          = $::freeradius::params::fr_package
-  $fr_service          = $::freeradius::params::fr_service
-  $fr_basepath         = $::freeradius::params::fr_basepath
   $fr_group            = $::freeradius::params::fr_group
   $fr_moduleconfigpath = $::freeradius::params::fr_moduleconfigpath
-  $fr_modulepath       = $::freeradius::params::fr_modulepath
 
   # Install the attribute filter snippet
-  file { "${fr_moduleconfigpath}/attr_filter/${name}":
+  file { "freeradius attr_filter/${name}":
     ensure  => $ensure,
+    path    => "${fr_moduleconfigpath}/attr_filter/${name}",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
     source  => $source,
-    require => [Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
 
   # Reference all attribute snippets in one file
-  concat::fragment { "attr-${name}":
-    target  => "${fr_basepath}/mods-available/attr_filter",
+  concat::fragment { "freeradius attr-${name}":
+    target  => 'freeradius mods-available/attr_filter',
     content => template('freeradius/attr.erb'),
     order   => 20,
   }

--- a/manifests/blank.pp
+++ b/manifests/blank.pp
@@ -1,21 +1,20 @@
 # Blank unneeded config files to reduce complexity
 define freeradius::blank {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
-  file { "${fr_basepath}/${name}":
+  file { "freeradius ${name}":
+    path    => "${fr_basepath}/${name}",
     mode    => '0644',
     owner   => 'root',
     group   => $fr_group,
-    require => [File[$fr_basepath], Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [File['freeradius raddb'], Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
     content => @(BLANK/L),
-      # This file is intentionally left blank to reduce complexity. \
-      Blanking it but leaving it present is safer than deleting it, \
-      since the package manager will replace some files if they are \
-      deleted, leading to unexpected behaviour!
-      |-BLANK
+               # This file is intentionally left blank to reduce complexity. \
+               Blanking it but leaving it present is safer than deleting it, \
+               since the package manager will replace some files if they are \
+               deleted, leading to unexpected behaviour!
+               |-BLANK
   }
 }

--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -5,8 +5,6 @@ define freeradius::cert (
   Optional[String] $type     = 'key',
   Freeradius::Ensure $ensure = present,
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
@@ -16,15 +14,16 @@ define freeradius::cert (
     default => '0644',
   }
 
-  file { "${fr_basepath}/certs/${name}":
+  file { "freeradius certs/${name}":
     ensure    => $ensure,
+    path      => "${fr_basepath}/certs/${name}",
     mode      => $permission,
     owner     => 'root',
     group     => $fr_group,
     source    => $source,
     content   => $content,
     show_diff => false,
-    require   => [File["${fr_basepath}/certs"], Package[$fr_package], Group[$fr_group]],
-    notify    => Service[$fr_service],
+    require   => [File['freeradius certs'], Package['freeradius'], Group['radiusd']],
+    notify    => Service['radiusd'],
   }
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -37,19 +37,18 @@ define freeradius::client (
   Variant[Array, Hash, String] $attributes           = [],
   Optional[String] $huntgroups                       = undef,
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
-  file { "${fr_basepath}/clients.d/${name}.conf":
+  file { "freeradius clients.d/${shortname}.conf":
     ensure  => $ensure,
+    path    => "${fr_basepath}/clients.d/${shortname}.conf",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
     content => template('freeradius/client.conf.erb'),
-    require => [File["${fr_basepath}/clients.d"], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [File['freeradius clients.d'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
 
   if ($firewall and $ensure == 'present') {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,19 +4,18 @@ define freeradius::config (
   Optional[String] $content  = undef,
   Freeradius::Ensure $ensure = present,
 ) {
-  $fr_package          = $::freeradius::params::fr_package
-  $fr_service          = $::freeradius::params::fr_service
   $fr_group            = $::freeradius::params::fr_group
   $fr_moduleconfigpath = $::freeradius::params::fr_moduleconfigpath
 
-  file { "${fr_moduleconfigpath}/${name}":
+  file { "freeradius mods-config/${name}":
     ensure  => $ensure,
+    path    => "${fr_moduleconfigpath}/${name}",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
     source  => $source,
     content => $content,
-    require => [Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
 }

--- a/manifests/dictionary.pp
+++ b/manifests/dictionary.pp
@@ -5,8 +5,6 @@ define freeradius::dictionary (
   Optional[Integer] $order   = 50,
   Freeradius::Ensure $ensure = 'present',
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
@@ -15,15 +13,16 @@ define freeradius::dictionary (
   }
 
   # Install dictionary in dictionary.d
-  file { "${fr_basepath}/dictionary.d/dictionary.${name}":
+  file { "freeradius dictionary.d/dictionary.${name}":
     ensure  => $ensure,
+    path    => "${fr_basepath}/dictionary.d/dictionary.${name}",
     mode    => '0644',
     owner   => 'root',
     group   => $fr_group,
     source  => $source,
     content => $content,
-    require => [File["${fr_basepath}/dictionary.d"], Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [File['freeradius dictionary.d'], Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
 
   # Reference policy.d in the global includes file
@@ -31,10 +30,10 @@ define freeradius::dictionary (
 
   if ($ensure == 'present') {
     concat::fragment { "dictionary.${name}":
-      target  => "${fr_basepath}/dictionary",
+      target  => 'freeradius dictionary',
       content => "\$INCLUDE ${fr_basepath}/dictionary.d/dictionary.${name}",
       order   => $order,
-      require => File["${fr_basepath}/dictionary.d/dictionary.${name}"],
+      require => File["freeradius dictionary.d/dictionary.${name}"],
     }
   }
 }

--- a/manifests/home_server.pp
+++ b/manifests/home_server.pp
@@ -20,11 +20,9 @@ define freeradius::home_server (
   Optional[String] $virtual_server                       = undef,
   Optional[Integer] $zombie_period                       = undef,
 ) {
-  $fr_basepath = $::freeradius::params::fr_basepath
-
   # Configure config fragment for this home server
   concat::fragment { "homeserver-${name}":
-    target  => "${fr_basepath}/proxy.conf",
+    target  => 'freeradius proxy.conf',
     content => template('freeradius/home_server.erb'),
     order   => 10,
   }

--- a/manifests/home_server_pool.pp
+++ b/manifests/home_server_pool.pp
@@ -5,11 +5,9 @@ define freeradius::home_server_pool (
   Optional[String] $virtual_server = undef,
   Optional[String] $fallback       = undef,
 ) {
-  $fr_basepath = $::freeradius::params::fr_basepath
-
   # Configure config fragment for this home server
   concat::fragment { "homeserverpool-${name}":
-    target  => "${fr_basepath}/proxy.conf",
+    target  => 'freeradius proxy.conf',
     content => template('freeradius/home_server_pool.erb'),
     order   => 20,
   }

--- a/manifests/huntgroup.pp
+++ b/manifests/huntgroup.pp
@@ -5,13 +5,10 @@ define freeradius::huntgroup (
   Optional[Array[String]] $conditions       = [],
   Optional[Variant[String, Integer]] $order = 50,
 ) {
-  $fr_basepath = $::freeradius::params::fr_basepath
-  $fr_service  = $::freeradius::params::fr_service
-
   concat::fragment { "huntgroup.${title}":
-    target  => "${fr_basepath}/mods-config/preprocess/huntgroups",
+    target  => 'freeradius mods-config/preprocess/huntgroups',
     content => template('freeradius/huntgroup.erb'),
     order   => $order,
-    notify  => Service[$fr_service],
+    notify  => Service['radiusd'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,62 +47,70 @@ class freeradius (
 
   # Always restart the service after every module operation
   Freeradius::Module {
-    notify => Service[$freeradius::fr_service]
+    notify => Service['radiusd']
   }
 
-  file { 'radiusd.conf':
+  file { 'freeradius radiusd.conf':
     name    => "${freeradius::fr_basepath}/radiusd.conf",
     mode    => '0644',
     owner   => 'root',
     group   => $freeradius::fr_group,
     content => template('freeradius/radiusd.conf.erb'),
     require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+    notify  => Service['radiusd'],
   }
 
   # Create various directories
-  file { [
-    "${freeradius::fr_basepath}/statusclients.d",
-    $freeradius::fr_basepath,
-    "${freeradius::fr_basepath}/conf.d",
-    "${freeradius::fr_basepath}/attr.d",
-    "${freeradius::fr_basepath}/users.d",
-    "${freeradius::fr_basepath}/policy.d",
-    "${freeradius::fr_basepath}/dictionary.d",
-    "${freeradius::fr_basepath}/scripts",
-    "${freeradius::fr_basepath}/mods-config",
-    "${freeradius::fr_basepath}/mods-config/attr_filter",
-    "${freeradius::fr_basepath}/mods-config/preprocess",
-    "${freeradius::fr_basepath}/mods-config/sql",
-    "${freeradius::fr_basepath}/sites-available",
-    "${freeradius::fr_basepath}/mods-available",
-  ]:
-    ensure  => directory,
-    mode    => '0755',
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+  $dirs = {
+    'freeradius statusclients.d' => "${freeradius::fr_basepath}/statusclients.d",
+    'freeradius raddb' => $freeradius::fr_basepath,
+    'freeradius conf.d' => "${freeradius::fr_basepath}/conf.d",
+    'freeradius attr.d' => "${freeradius::fr_basepath}/attr.d",
+    'freeradius users.d' => "${freeradius::fr_basepath}/users.d",
+    'freeradius policy.d' => "${freeradius::fr_basepath}/policy.d",
+    'freeradius dictionary.d' => "${freeradius::fr_basepath}/dictionary.d",
+    'freeradius scripts' => "${freeradius::fr_basepath}/scripts",
+    'freeradius mods-config' => "${freeradius::fr_basepath}/mods-config",
+    'freeradius mods-config/attr_filter' => "${freeradius::fr_basepath}/mods-config/attr_filter",
+    'freeradius mods-config/preprocess' => "${freeradius::fr_basepath}/mods-config/preprocess",
+    'freeradius mods-config/sql' => "${freeradius::fr_basepath}/mods-config/sql",
+    'freeradius sites-available' => "${freeradius::fr_basepath}/sites-available",
+    'freeradius mods-available' => "${freeradius::fr_basepath}/mods-available",
+  }
+  $dirs.each |$name, $path| {
+    file { $name:
+      ensure  => directory,
+      path    => $path,
+      mode    => '0755',
+      owner   => 'root',
+      group   => $freeradius::fr_group,
+      require => [Package['freeradius'], Group['radiusd']],
+      notify  => Service['radiusd'],
+    }
   }
 
   # Create these directories separately so we can set purge option
   # Anything in these dirs NOT managed by puppet will be removed!
-  file { [
-    "${freeradius::fr_basepath}/certs",
-    "${freeradius::fr_basepath}/clients.d",
-    "${freeradius::fr_basepath}/listen.d",
-    "${freeradius::fr_basepath}/sites-enabled",
-    "${freeradius::fr_basepath}/mods-enabled",
-    "${freeradius::fr_basepath}/instantiate",
-  ]:
-    ensure  => directory,
-    purge   => true,
-    recurse => true,
-    mode    => '0755',
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+  $purged_dirs = {
+    'freeradius certs' => "${freeradius::fr_basepath}/certs",
+    'freeradius clients.d' => "${freeradius::fr_basepath}/clients.d",
+    'freeradius listen.d' => "${freeradius::fr_basepath}/listen.d",
+    'freeradius sites-enabled' => "${freeradius::fr_basepath}/sites-enabled",
+    'freeradius mods-enabled' => "${freeradius::fr_basepath}/mods-enabled",
+    'freeradius instantiate' => "${freeradius::fr_basepath}/instantiate",
+  }
+  $purged_dirs.each |$name, $path| {
+    file { $name:
+      ensure  => directory,
+      path    => $path,
+      purge   => true,
+      recurse => true,
+      mode    => '0755',
+      owner   => 'root',
+      group   => $freeradius::fr_group,
+      require => [Package['freeradius'], Group['radiusd']],
+      notify  => Service['radiusd'],
+    }
   }
 
   # Preserve some stock modules
@@ -142,140 +150,152 @@ class freeradius (
 
   # Set up concat policy file, as there is only one global policy
   # We also add standard header and footer
-  concat { "${freeradius::fr_basepath}/policy.conf":
+  concat { 'freeradius policy.conf':
+    path           => "${freeradius::fr_basepath}/policy.conf",
     owner          => 'root',
     group          => $freeradius::fr_group,
     mode           => '0640',
     ensure_newline => true,
-    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify         => Service[$freeradius::fr_service],
+    require        => [Package['freeradius'], Group['radiusd']],
+    notify         => Service['radiusd'],
   }
   concat::fragment { 'policy_header':
-    target  => "${freeradius::fr_basepath}/policy.conf",
+    target  => 'freeradius policy.conf',
     content => 'policy {',
     order   => 10,
   }
   concat::fragment { 'policy_footer':
-    target  => "${freeradius::fr_basepath}/policy.conf",
+    target  => 'freeradius policy.conf',
     content => '}',
     order   => '99',
   }
 
   # Set up concat template file
-  concat { "${freeradius::fr_basepath}/templates.conf":
+  concat { 'freeradius templates.conf':
+    path           => "${freeradius::fr_basepath}/templates.conf",
     owner          => 'root',
     group          => $freeradius::fr_group,
     mode           => '0640',
     ensure_newline => true,
-    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify         => Service[$freeradius::fr_service],
+    require        => [Package['freeradius'], Group['radiusd']],
+    notify         => Service['radiusd'],
   }
   concat::fragment { 'template_header':
-    target => "${freeradius::fr_basepath}/templates.conf",
+    target => 'freeradius templates.conf',
     source => 'puppet:///modules/freeradius/template.header',
     order  => '05',
   }
   concat::fragment { 'template_footer':
-    target  => "${freeradius::fr_basepath}/templates.conf",
+    target  => 'freeradius templates.conf',
     content => '}',
     order   => '95',
   }
 
   # Set up concat proxy file
-  concat { "${freeradius::fr_basepath}/proxy.conf":
+  concat { 'freeradius proxy.conf':
+    path           => "${freeradius::fr_basepath}/proxy.conf",
     owner          => 'root',
     group          => $freeradius::fr_group,
     mode           => '0640',
     ensure_newline => true,
-    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify         => Service[$freeradius::fr_service],
+    require        => [Package['freeradius'], Group['radiusd']],
+    notify         => Service['radiusd'],
   }
   concat::fragment { 'proxy_header':
-    target  => "${freeradius::fr_basepath}/proxy.conf",
+    target  => 'freeradius proxy.conf',
     content => '# Proxy config',
     order   => '05',
   }
 
   # Set up attribute filter file
-  concat { "${freeradius::fr_basepath}/mods-available/attr_filter":
+  concat { 'freeradius mods-available/attr_filter':
+    path           => "${freeradius::fr_basepath}/mods-available/attr_filter",
     owner          => 'root',
     group          => $freeradius::fr_group,
     mode           => '0640',
     ensure_newline => true,
-    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify         => Service[$freeradius::fr_service],
+    require        => [Package['freeradius'], Group['radiusd']],
+    notify         => Service['radiusd'],
   }
-  file { "${freeradius::fr_modulepath}/attr_filter":
+  file { 'freeradius mods-enabled/attr_filter':
     ensure => link,
+    path   => "${freeradius::fr_modulepath}/attr_filter",
     target => '../mods-available/attr_filter',
-    notify => Service[$freeradius::fr_service],
+    notify => Service['radiusd'],
   }
 
   # Install default attribute filters
   concat::fragment { 'attr-default':
-    target  => "${freeradius::fr_basepath}/mods-available/attr_filter",
+    target  => 'freeradius mods-available/attr_filter',
     content => template('freeradius/attr_default.erb'),
     order   => 10,
   }
 
   # Manage the file permissions for files defined in attr_filter
-  file { [
-    "${freeradius::fr_basepath}/mods-config/attr_filter/access_challenge",
-    "${freeradius::fr_basepath}/mods-config/attr_filter/access_reject",
-    "${freeradius::fr_basepath}/mods-config/attr_filter/accounting_response",
-    "${freeradius::fr_basepath}/mods-config/attr_filter/post-proxy",
-    "${freeradius::fr_basepath}/mods-config/attr_filter/pre-proxy",
-  ]:
-    ensure  => 'present',
-    mode    => '0640',
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+  $attr_filter_files = {
+    'freeradius mods-config/attr_filter/access_challenge' => "${freeradius::fr_basepath}/mods-config/attr_filter/access_challenge",
+    'freeradius mods-config/attr_filter/access_reject' => "${freeradius::fr_basepath}/mods-config/attr_filter/access_reject",
+    'freeradius mods-config/attr_filter/accounting_response' => "${freeradius::fr_basepath}/mods-config/attr_filter/accounting_response",
+    'freeradius mods-config/attr_filter/post-proxy' => "${freeradius::fr_basepath}/mods-config/attr_filter/post-proxy",
+    'freeradius mods-config/attr_filter/pre-proxy' => "${freeradius::fr_basepath}/mods-config/attr_filter/pre-proxy",
+  }
+  $attr_filter_files.each |$name, $path| {
+    file { $name:
+      ensure  => present,
+      path    => $path,
+      mode    => '0640',
+      owner   => 'root',
+      group   => $freeradius::fr_group,
+      require => [Package['freeradius'], Group['radiusd']],
+      notify  => Service['radiusd'],
+    }
   }
 
   # Install a slightly tweaked stock dictionary that includes
   # our custom dictionaries
-  concat { "${freeradius::fr_basepath}/dictionary":
+  concat { 'freeradius dictionary':
+    path           => "${freeradius::fr_basepath}/dictionary",
     owner          => 'root',
     group          => $freeradius::fr_group,
     mode           => '0644',
     ensure_newline => true,
-    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
+    require        => [Package['freeradius'], Group['radiusd']],
   }
-  concat::fragment { 'dictionary_header':
-    target => "${freeradius::fr_basepath}/dictionary",
+  concat::fragment { 'freeradius dictionary_header':
+    target => 'freeradius dictionary',
     source => 'puppet:///modules/freeradius/dictionary.header',
     order  => 10,
   }
-  concat::fragment { 'dictionary_footer':
-    target => "${freeradius::fr_basepath}/dictionary",
+  concat::fragment { 'freeradius dictionary_footer':
+    target => 'freeradius dictionary',
     source => 'puppet:///modules/freeradius/dictionary.footer',
     order  => 90,
   }
 
   # Install a huntgroups file
-  concat { "${freeradius::fr_basepath}/mods-config/preprocess/huntgroups":
+  concat { 'freeradius mods-config/preprocess/huntgroups':
+    path           => "${freeradius::fr_basepath}/mods-config/preprocess/huntgroups",
     owner          => 'root',
     group          => $freeradius::fr_group,
     mode           => '0640',
     ensure_newline => true,
-    require        => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify         => Service[$freeradius::fr_service],
+    require        => [Package['freeradius'], Group['radiusd']],
+    notify         => Service['radiusd'],
   }
-  concat::fragment { 'huntgroups_header':
-    target => "${freeradius::fr_basepath}/mods-config/preprocess/huntgroups",
+  concat::fragment { 'freeradius huntgroups_header':
+    target => 'freeradius mods-config/preprocess/huntgroups',
     source => 'puppet:///modules/freeradius/huntgroups.header',
     order  => 10,
   }
 
   # Fix the permissions on the hints file
-  file { "${freeradius::fr_basepath}/mods-config/preprocess/hints":
-    ensure  => 'present',
+  file { 'freeradius mods-config/preprocess/hints':
+    ensure  => present,
+    path    => "${freeradius::fr_basepath}/mods-config/preprocess/hints",
     mode    => '0640',
     owner   => 'root',
     group   => $freeradius::fr_group,
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
+    require => [Package['freeradius'], Group['radiusd']],
   }
 
   # Install FreeRADIUS packages
@@ -286,36 +306,43 @@ class freeradius (
   if $mysql_support {
     package { 'freeradius-mysql':
       ensure => $package_ensure,
+      name   => 'freeradius-mysql',
     }
   }
   if $pgsql_support {
     package { 'freeradius-postgresql':
       ensure => $package_ensure,
+      name   => 'freeradius-postgresql',
     }
   }
   if $perl_support {
     package { 'freeradius-perl':
       ensure => $package_ensure,
+      name   => 'freeradius-perl',
     }
   }
   if $utils_support {
     package { 'freeradius-utils':
       ensure => $package_ensure,
+      name   => 'freeradius-utils',
     }
   }
   if $ldap_support {
     package { 'freeradius-ldap':
       ensure => $package_ensure,
+      name   => 'freeradius-ldap',
     }
   }
   if $dhcp_support {
     package { 'freeradius-dhcp':
       ensure => $package_ensure,
+      name   => 'freeradius-dhcp',
     }
   }
   if $krb5_support {
     package { 'freeradius-krb5':
       ensure => $package_ensure,
+      name   => 'freeradius-krb5',
     }
   }
   if $wpa_supplicant {
@@ -327,10 +354,10 @@ class freeradius (
 
   # radiusd always tests its config before restarting the service, to avoid outage. If the config is not valid, the service
   # won't get restarted, and the puppet run will fail.
-  service { $freeradius::fr_service:
+  service { 'radiusd':
     ensure     => running,
     name       => $freeradius::fr_service,
-    require    => [Exec['radiusd-config-test'], File['radiusd.conf'], User[$freeradius::fr_user], Package[$freeradius::fr_package],],
+    require    => [Exec['radiusd-config-test'], File['freeradius radiusd.conf'], User['radiusd'], Package['freeradius'],],
     enable     => true,
     hasstatus  => $freeradius::fr_service_has_status,
     hasrestart => true,
@@ -343,18 +370,20 @@ class freeradius (
     true    => $freeradius::fr_wbpriv_user,
     default => undef,
   }
-  user { $freeradius::fr_user:
+  user { 'radiusd':
     ensure  => present,
+    name    => $freeradius::fr_user,
     groups  => $fr_user_group,
-    require => Package[$freeradius::fr_package],
+    require => Package['freeradius'],
   }
 
   # We don't want to add the radiusd group but it must be defined
   # here so we can depend on it. WE depend on the FreeRADIUS
   # package to be sure that the group has been created.
-  group { $freeradius::fr_group:
+  group { 'radiusd':
     ensure  => present,
-    require => Package[$freeradius::fr_package],
+    name    => $freeradius::fr_group,
+    require => Package['freeradius'],
   }
 
   # Syslog rules
@@ -366,21 +395,26 @@ class freeradius (
 
   if $manage_logpath {
     # Make the radius log dir traversable
-    file { [
-      $freeradius::fr_logpath,
-      "${freeradius::fr_logpath}/radacct",
-    ]:
-      group   => $freeradius::fr_group,
-      mode    => '0750',
-      owner   => $freeradius::fr_user,
-      require => Package[$freeradius::fr_package],
+    $logdirs = {
+      'freeradius logdir' => $freeradius::fr_logpath,
+      'freeradius logdir/radacct' => "${freeradius::fr_logpath}/radacct",
+    }
+    $logdirs.each |$name, $path| {
+      file { $name:
+        path    => $path,
+        group   => $freeradius::fr_group,
+        mode    => '0750',
+        owner   => $freeradius::fr_user,
+        require => Package['freeradius'],
+      }
     }
 
-    file { "${freeradius::fr_logpath}/radius.log":
+    file { 'freeradius radius.log':
+      path    => "${freeradius::fr_logpath}/radius.log",
       owner   => $freeradius::fr_user,
       group   => $freeradius::fr_group,
       seltype => 'radiusd_log_t',
-      require => [Package[$freeradius::fr_package], User[$freeradius::fr_user], Group[$freeradius::fr_group]],
+      require => [Package['freeradius'], User['radiusd'], Group['radiusd']],
     }
   }
 
@@ -419,24 +453,31 @@ class freeradius (
 
   # Placeholder resource for dh and random as they are dynamically generated, so they
   # exist in the catalogue and don't get purged
-  file { ["${freeradius::fr_basepath}/certs/dh", "${freeradius::fr_basepath}/certs/random"]:
-    require => Exec['dh', 'random'],
+  $cert_files = {
+    'freeradius certs/dh' => "${freeradius::fr_basepath}/certs/dh",
+    'freeradius certs/random' => "${freeradius::fr_basepath}/certs/random",
+  }
+  $cert_files.each |$name,$path| {
+    file { $name:
+      path    => $path,
+      require => Exec['freeradius dh', 'freeradius random'],
+    }
   }
 
   # Generate global SSL parameters
-  exec { 'dh':
+  exec { 'freeradius dh':
     command => "openssl dhparam -out ${freeradius::fr_basepath}/certs/dh 1024",
     creates => "${freeradius::fr_basepath}/certs/dh",
     path    => '/usr/bin',
-    require => File["${freeradius::fr_basepath}/certs"],
+    require => File['freeradius certs'],
   }
 
   # Generate global SSL parameters
-  exec { 'random':
+  exec { 'freeradius random':
     command => "dd if=/dev/urandom of=${freeradius::fr_basepath}/certs/random count=10 >/dev/null 2>&1",
     creates => "${freeradius::fr_basepath}/certs/random",
     path    => '/bin',
-    require => File["${freeradius::fr_basepath}/certs"],
+    require => File['freeradius certs'],
   }
 
   # This exec tests the radius config and fails if it's bad
@@ -451,16 +492,20 @@ class freeradius (
 
   # Blank a couple of default files that will break our config. This is more effective than deleting them
   # as they won't get overwritten when FR is upgraded from RPM, whereas missing files are replaced.
-  file { [
-    "${freeradius::fr_basepath}/clients.conf",
-    "${freeradius::fr_basepath}/sql.conf",
-  ]:
-    content => '# FILE INTENTIONALLY BLANK',
-    mode    => '0644',
-    owner   => 'root',
-    group   => $freeradius::fr_group,
-    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
-    notify  => Service[$freeradius::fr_service],
+  $blank_files = {
+    'freeradius clients.conf' => "${freeradius::fr_basepath}/clients.conf",
+    'freeradius sql.conf' => "${freeradius::fr_basepath}/sql.conf",
+  }
+  $blank_files.each |$name, $path| {
+    file { $name:
+      path    => $path,
+      content => '# FILE INTENTIONALLY BLANK',
+      mode    => '0644',
+      owner   => 'root',
+      group   => $freeradius::fr_group,
+      require => [Package['freeradius'], Group['radiusd']],
+      notify  => Service['radiusd'],
+    }
   }
 
   # Delete *.rpmnew and *.rpmsave files from the radius config dir because

--- a/manifests/instantiate.pp
+++ b/manifests/instantiate.pp
@@ -2,18 +2,17 @@
 define freeradius::instantiate (
   Freeradius::Ensure $ensure = present,
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
-  file { "${fr_basepath}/instantiate/${name}":
+  file { "freeradius instantiate/${name}":
     ensure  => $ensure,
+    path    => "${fr_basepath}/instantiate/${name}",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
     content => $name,
-    require => [Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
 }

--- a/manifests/krb5.pp
+++ b/manifests/krb5.pp
@@ -8,24 +8,24 @@ define freeradius::krb5 (
   Freeradius::Integer  $spare = "\${thread[pool].max_spare_servers}",
   Freeradius::Ensure $ensure  = 'present',
 ) {
-  $fr_package          = $::freeradius::params::fr_package
-  $fr_service          = $::freeradius::params::fr_service
   $fr_modulepath       = $::freeradius::params::fr_modulepath
   $fr_basepath         = $::freeradius::params::fr_basepath
   $fr_group            = $::freeradius::params::fr_group
 
   # Generate a module config
-  file { "${fr_basepath}/mods-available/${name}":
+  file { "freeradius mods-available/${name}":
     ensure  => $ensure,
+    path    => "${fr_basepath}/mods-available/${name}",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
     content => template('freeradius/krb5.erb'),
-    require => [Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
-  file { "${fr_modulepath}/${name}":
+  file { "freeradius mods-enabled/${name}":
     ensure => link,
+    path   => "${fr_modulepath}/${name}",
     target => "../mods-available/${name}",
   }
 }

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -13,8 +13,6 @@ define freeradius::listen (
   Integer $lifetime                                         = 0,
   Integer $idle_timeout                                     = 30,
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
@@ -31,16 +29,17 @@ define freeradius::listen (
     fail('Only one of ip or ip6 can be used')
   }
 
-  file { "${fr_basepath}/listen.d/${name}.conf":
+  file { "freeradius listen.d/${name}.conf":
     ensure  => $ensure,
+    path    => "${fr_basepath}/listen.d/${name}.conf",
     owner   => 'root',
     group   => $fr_group,
     mode    => '0640',
     content => template('freeradius/listen.erb'),
     require => [
-      File["${fr_basepath}/listen.d"],
-      Group[$fr_group],
+      File['freeradius listen.d'],
+      Group['radiusd'],
     ],
-    notify  => Service[$fr_service],
+    notify  => Service['radiusd'],
   }
 }

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -5,8 +5,6 @@ define freeradius::module (
   Freeradius::Ensure $ensure = present,
   Boolean $preserve          = false,
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_modulepath = $::freeradius::params::fr_modulepath
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
@@ -18,28 +16,31 @@ define freeradius::module (
 
   if ($preserve) {
     # Symlink to mods-available for stock modules
-    file { "${fr_modulepath}/${name}":
+    file { "freeradius mods-enabled/${name}":
       ensure => $ensure_link,
+      path   => "${fr_modulepath}/${name}",
       target => "../mods-available/${name}",
-      notify => Service[$fr_service],
+      notify => Service['radiusd'],
     }
   } else {
     # Deploy actual module to mods-available, and link it to mods-enabled
-    file { "${fr_basepath}/mods-available/${name}":
+    file { "freeradius mods-available/${name}":
       ensure  => $ensure,
+      path    => "${fr_basepath}/mods-available/${name}",
       mode    => '0640',
       owner   => 'root',
       group   => $fr_group,
       source  => $source,
       content => $content,
-      require => [Package[$fr_package], Group[$fr_group]],
-      notify  => Service[$fr_service],
+      require => [Package['freeradius'], Group['radiusd']],
+      notify  => Service['radiusd'],
     }
-    file { "${fr_modulepath}/${name}":
+    file { "freeradius mods-enabled/${name}":
       ensure  => $ensure_link,
+      path    => "${fr_modulepath}/${name}",
       target  => "../mods-available/${name}",
-      require => File["${fr_basepath}/mods-available/${name}"],
-      notify  => Service[$fr_service],
+      require => File["freeradius mods-available/${name}"],
+      notify  => Service['radiusd'],
     }
   }
 }

--- a/manifests/module/ldap.pp
+++ b/manifests/module/ldap.pp
@@ -153,8 +153,9 @@ define freeradius::module::ldap (
   }
 
   # Generate a module config, based on ldap.conf
-  file { "${fr_basepath}/mods-available/${name}":
+  file { "freeradius mods-available/${name}":
     ensure  => $ensure,
+    path    => "${fr_basepath}/mods-available/${name}",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
@@ -162,8 +163,9 @@ define freeradius::module::ldap (
     require => [Package[$fr_package], Group[$fr_group]],
     notify  => Service[$fr_service],
   }
-  file { "${fr_modulepath}/${name}":
+  file { "freeradius mods-enabled/${name}":
     ensure => link,
+    path   => "${fr_modulepath}/${name}",
     target => "../mods-available/${name}",
   }
 }

--- a/manifests/policy.pp
+++ b/manifests/policy.pp
@@ -4,30 +4,29 @@ define freeradius::policy (
   Optional[Integer] $order   = 50,
   Freeradius::Ensure $ensure = present,
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
   # Install policy in policy.d
-  file { "${fr_basepath}/policy.d/${name}":
+  file { "freeradius policy.d/${name}":
     ensure  => $ensure,
+    path    => "${fr_basepath}/policy.d/${name}",
     mode    => '0644',
     owner   => 'root',
     group   => $fr_group,
     source  => $source,
-    require => [Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
 
   # Reference policy.d in the global includes file
   # If no order priority is given, assume 50
   if ($ensure == 'present') {
-    concat::fragment { "policy-${name}":
-      target  => "${fr_basepath}/policy.conf",
+    concat::fragment { "freeradius policy-${name}":
+      target  => 'freeradius policy.conf',
       content => "\t\$INCLUDE ${fr_basepath}/policy.d/${name}",
       order   => $order,
-      require => File["${fr_basepath}/policy.d/${name}"],
+      require => File["freeradius policy.d/${name}"],
     }
   }
 }

--- a/manifests/radsniff.pp
+++ b/manifests/radsniff.pp
@@ -36,7 +36,8 @@ class freeradius::radsniff (
 
   $escaped_cmd = $options.regsubst('"','\\\\"','G')
 
-  file { $final_envfile:
+  file { 'freeradius radsniff envfile':
+    path    => $final_envfile,
     content => @("SYSCONFIG"),
       RADSNIFF_OPTIONS="${escaped_cmd}"
       | SYSCONFIG

--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -7,11 +7,9 @@ define freeradius::realm (
   Optional[Boolean] $nostrip       = false,
   Optional[Integer] $order         = 30,
 ) {
-  $fr_basepath = $::freeradius::params::fr_basepath
-
   # Configure config fragment for this realm
-  concat::fragment { "realm-${name}":
-    target  => "${fr_basepath}/proxy.conf",
+  concat::fragment { "freeradius realm-${name}":
+    target  => 'freeradius proxy.conf',
     content => template('freeradius/realm.erb'),
     order   => $order,
   }

--- a/manifests/script.pp
+++ b/manifests/script.pp
@@ -3,18 +3,17 @@ define freeradius::script (
   String $source,
   Freeradius::Ensure $ensure = present,
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
-  file { "${fr_basepath}/scripts/${name}":
+  file { "freeradius scripts/${name}":
+    path    => "${fr_basepath}/scripts/${name}",
     ensure  => $ensure,
     mode    => '0750',
     owner   => 'root',
     group   => $fr_group,
     source  => $source,
-    require => [File["${fr_basepath}/scripts"], Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [File['freeradius scripts'], Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -13,8 +13,6 @@ define freeradius::site (
   Array[String] $post_proxy   = [],
   Array[Hash] $listen         = [],
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
@@ -31,18 +29,20 @@ define freeradius::site (
     default  => 'link'
   }
 
-  file { "${fr_basepath}/sites-available/${name}":
+  file { "freeradius sites-available/${name}":
     ensure  => $ensure,
+    path    => "${fr_basepath}/sites-available/${name}",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
     source  => $source,
     content => $manage_content,
-    require => [Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
-  file { "${fr_basepath}/sites-enabled/${name}":
+  file { "freeradius sites-enabled/${name}":
     ensure => $ensure_link,
+    path   => "${fr_basepath}/sites-enabled/${name}",
     target => "${fr_basepath}/sites-available/${name}",
   }
 }

--- a/manifests/sql.pp
+++ b/manifests/sql.pp
@@ -33,8 +33,6 @@ define freeradius::sql (
   Optional[Integer] $pool_idle_timeout                                              = 60,
   Optional[Float] $pool_connect_timeout                                             = undef,
 ) {
-  $fr_package          = $::freeradius::params::fr_package
-  $fr_service          = $::freeradius::params::fr_service
   $fr_basepath         = $::freeradius::params::fr_basepath
   $fr_modulepath       = $::freeradius::params::fr_modulepath
   $fr_group            = $::freeradius::params::fr_group
@@ -86,17 +84,19 @@ define freeradius::sql (
   }
 
   # Generate a module config, based on sql.conf
-  file { "${fr_basepath}/mods-available/${name}":
+  file { "freeradius mods-available/${name}":
     ensure  => $ensure,
+    path    => "${fr_basepath}/mods-available/${name}",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
     content => template('freeradius/sql.conf.erb'),
-    require => [Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
-  file { "${fr_modulepath}/${name}":
+  file { "freeradius mods-enabled/${name}":
     ensure => link,
+    path   => "${fr_modulepath}/${name}",
     target => "../mods-available/${name}",
   }
 

--- a/manifests/statusclient.pp
+++ b/manifests/statusclient.pp
@@ -7,18 +7,17 @@ define freeradius::statusclient (
   Optional[String] $shortname = $name,
   Freeradius::Ensure $ensure  = present,
 ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
-  file { "${fr_basepath}/statusclients.d/${name}.conf":
+  file { "freeradius statusclients.d/${name}.conf":
     ensure  => $ensure,
+    path    => "${fr_basepath}/statusclients.d/${name}.conf",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
     content => template('freeradius/client.conf.erb'),
-    require => [File["${fr_basepath}/clients.d"], Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [File['freeradius clients.d'], Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
 }

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -3,11 +3,9 @@ define freeradius::template (
   Optional[String] $source  = undef,
   Optional[String] $content = undef,
 ) {
-  $fr_basepath = $::freeradius::params::fr_basepath
-
   # Configure config fragment for this template
-  concat::fragment { "template -${name}":
-    target  => "${fr_basepath}/templates.conf",
+  concat::fragment { "freeradius template ${name}":
+    target  => 'freeradius templates.conf',
     source  => $source,
     content => $content,
     order   => 10,

--- a/manifests/virtual_module.pp
+++ b/manifests/virtual_module.pp
@@ -4,18 +4,17 @@ define freeradius::virtual_module (
   Freeradius::Ensure $ensure = present,
   Enum['redundant','load-balance','redundant-load-balance','group'] $type = 'redundant-load-balance',
   ) {
-  $fr_package  = $::freeradius::params::fr_package
-  $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
-  file { "${fr_basepath}/instantiate/${name}":
+  file { "freeradius instantiate/${name}":
     ensure  => $ensure,
+    path    => "${fr_basepath}/instantiate/${name}",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,
     content => template('freeradius/virtual_module.erb'),
-    require => [Package[$fr_package], Group[$fr_group]],
-    notify  => Service[$fr_service],
+    require => [Package['freeradius'], Group['radiusd']],
+    notify  => Service['radiusd'],
   }
 }

--- a/spec/classes/freeradius_spec.rb
+++ b/spec/classes/freeradius_spec.rb
@@ -11,7 +11,7 @@ describe 'freeradius' do
       let(:params) { {} }
 
       it do
-        is_expected.to contain_file('radiusd.conf')
+        is_expected.to contain_file('freeradius radiusd.conf')
           .with(
             'group'  => 'radiusd',
             'mode'   => '0644',
@@ -24,23 +24,24 @@ describe 'freeradius' do
       end
 
       it do
-        [
-          '/etc/raddb/statusclients.d',
-          '/etc/raddb',
-          '/etc/raddb/conf.d',
-          '/etc/raddb/attr.d',
-          '/etc/raddb/users.d',
-          '/etc/raddb/policy.d',
-          '/etc/raddb/dictionary.d',
-          '/etc/raddb/scripts',
-          '/etc/raddb/mods-config',
-          '/etc/raddb/mods-config/attr_filter',
-          '/etc/raddb/mods-config/preprocess',
-          '/etc/raddb/mods-config/sql',
-          '/etc/raddb/sites-available',
-          '/etc/raddb/mods-available',
-        ].each do |file|
-          is_expected.to contain_file(file)
+        {
+          'freeradius statusclients.d': '/etc/raddb/statusclients.d',
+          'freeradius raddb': '/etc/raddb',
+          'freeradius conf.d': '/etc/raddb/conf.d',
+          'freeradius attr.d': '/etc/raddb/attr.d',
+          'freeradius users.d': '/etc/raddb/users.d',
+          'freeradius policy.d': '/etc/raddb/policy.d',
+          'freeradius dictionary.d': '/etc/raddb/dictionary.d',
+          'freeradius scripts': '/etc/raddb/scripts',
+          'freeradius mods-config': '/etc/raddb/mods-config',
+          'freeradius mods-config/attr_filter': '/etc/raddb/mods-config/attr_filter',
+          'freeradius mods-config/preprocess': '/etc/raddb/mods-config/preprocess',
+          'freeradius mods-config/sql': '/etc/raddb/mods-config/sql',
+          'freeradius sites-available': '/etc/raddb/sites-available',
+          'freeradius mods-available': '/etc/raddb/mods-available',
+        }.each do |name, path|
+          is_expected.to contain_file(name)
+            .with_path(path)
             .with(
               'ensure'  => 'directory',
               'group'   => 'radiusd',
@@ -54,14 +55,15 @@ describe 'freeradius' do
       end
 
       it do
-        [
-          '/etc/raddb/certs',
-          '/etc/raddb/clients.d',
-          '/etc/raddb/listen.d',
-          '/etc/raddb/sites-enabled',
-          '/etc/raddb/instantiate',
-        ].each do |file|
-          is_expected.to contain_file(file)
+        {
+          'freeradius certs': '/etc/raddb/certs',
+          'freeradius clients.d': '/etc/raddb/clients.d',
+          'freeradius listen.d': '/etc/raddb/listen.d',
+          'freeradius sites-enabled': '/etc/raddb/sites-enabled',
+          'freeradius instantiate': '/etc/raddb/instantiate',
+        }.each do |name, path|
+          is_expected.to contain_file(name)
+            .with_path(path)
             .with(
               'ensure'  => 'directory',
               'group'   => 'radiusd',
@@ -77,7 +79,8 @@ describe 'freeradius' do
       end
 
       it do
-        is_expected.to contain_concat('/etc/raddb/policy.conf')
+        is_expected.to contain_concat('freeradius policy.conf')
+          .with_path('/etc/raddb/policy.conf')
           .with(
             'group'          => 'radiusd',
             'mode'           => '0640',
@@ -94,7 +97,7 @@ describe 'freeradius' do
           .with(
             'content' => 'policy {',
             'order'   => '10',
-            'target'  => '/etc/raddb/policy.conf',
+            'target'  => 'freeradius policy.conf',
           )
       end
 
@@ -103,12 +106,13 @@ describe 'freeradius' do
           .with(
             'content' => '}',
             'order'   => '99',
-            'target'  => '/etc/raddb/policy.conf',
+            'target'  => 'freeradius policy.conf',
           )
       end
 
       it do
-        is_expected.to contain_concat('/etc/raddb/proxy.conf')
+        is_expected.to contain_concat('freeradius proxy.conf')
+          .with_path('/etc/raddb/proxy.conf')
           .with(
             'group'          => 'radiusd',
             'mode'           => '0640',
@@ -125,12 +129,13 @@ describe 'freeradius' do
           .with(
             'content' => '# Proxy config',
             'order'   => '05',
-            'target'  => '/etc/raddb/proxy.conf',
+            'target'  => 'freeradius proxy.conf',
           )
       end
 
       it do
-        is_expected.to contain_concat('/etc/raddb/mods-available/attr_filter')
+        is_expected.to contain_concat('freeradius mods-available/attr_filter')
+          .with_path('/etc/raddb/mods-available/attr_filter')
           .with(
             'group'          => 'radiusd',
             'mode'           => '0640',
@@ -146,12 +151,13 @@ describe 'freeradius' do
         is_expected.to contain_concat__fragment('attr-default')
           .with(
             'order'   => '10',
-            'target'  => '/etc/raddb/mods-available/attr_filter',
+            'target'  => 'freeradius mods-available/attr_filter',
           )
       end
 
       it do
-        is_expected.to contain_concat('/etc/raddb/dictionary')
+        is_expected.to contain_concat('freeradius dictionary')
+          .with_path('/etc/raddb/dictionary')
           .with(
             'group'          => 'radiusd',
             'mode'           => '0644',
@@ -163,20 +169,20 @@ describe 'freeradius' do
       end
 
       it do
-        is_expected.to contain_concat__fragment('dictionary_header')
+        is_expected.to contain_concat__fragment('freeradius dictionary_header')
           .with(
             'order'  => '10',
             'source' => 'puppet:///modules/freeradius/dictionary.header',
-            'target' => '/etc/raddb/dictionary',
+            'target' => 'freeradius dictionary',
           )
       end
 
       it do
-        is_expected.to contain_concat__fragment('dictionary_footer')
+        is_expected.to contain_concat__fragment('freeradius dictionary_footer')
           .with(
             'order'  => '90',
             'source' => 'puppet:///modules/freeradius/dictionary.footer',
-            'target' => '/etc/raddb/dictionary',
+            'target' => 'freeradius dictionary',
           )
       end
 
@@ -200,7 +206,7 @@ describe 'freeradius' do
           .that_requires('Package[freeradius]')
           .that_requires('User[radiusd]')
           .that_requires('Exec[radiusd-config-test]')
-          .that_requires('File[radiusd.conf]')
+          .that_requires('File[freeradius radiusd.conf]')
       end
 
       it do
@@ -221,6 +227,7 @@ describe 'freeradius' do
 
         it do
           is_expected.to contain_user('radiusd')
+            .with_name('radiusd')
             .with(
               'groups'  => 'wbpriv',
             )
@@ -229,6 +236,7 @@ describe 'freeradius' do
 
       it do
         is_expected.to contain_group('radiusd')
+          .with_name('radiusd')
           .with(
             'ensure' => 'present',
           )
@@ -251,11 +259,12 @@ describe 'freeradius' do
       end
 
       it do
-        [
-          '/var/log/radius',
-          '/var/log/radius/radacct',
-        ].each do |file|
-          is_expected.to contain_file(file)
+        {
+          'freeradius logdir': '/var/log/radius',
+          'freeradius logdir/radacct': '/var/log/radius/radacct',
+        }.each do |name, path|
+          is_expected.to contain_file(name)
+            .with_path(path)
             .with(
               'mode'    => '0750',
               'owner' => 'radiusd',
@@ -266,7 +275,8 @@ describe 'freeradius' do
       end
 
       it do
-        is_expected.to contain_file('/var/log/radius/radius.log')
+        is_expected.to contain_file('freeradius radius.log')
+          .with_path('/var/log/radius/radius.log')
           .with(
             'group'   => 'radiusd',
             'owner'   => 'radiusd',
@@ -320,34 +330,35 @@ describe 'freeradius' do
       end
 
       it do
-        [
-          '/etc/raddb/certs/dh',
-          '/etc/raddb/certs/random',
-        ].each do |file|
-          is_expected.to contain_file(file)
-            .that_requires('Exec[dh]')
-            .that_requires('Exec[random]')
+        {
+          'freeradius certs/dh': '/etc/raddb/certs/dh',
+          'freeradius certs/random': '/etc/raddb/certs/random',
+        }.each do |name, path|
+          is_expected.to contain_file(name)
+            .with_path(path)
+            .that_requires('Exec[freeradius dh]')
+            .that_requires('Exec[freeradius random]')
         end
       end
 
       it do
-        is_expected.to contain_exec('dh')
+        is_expected.to contain_exec('freeradius dh')
           .with(
             'command' => 'openssl dhparam -out /etc/raddb/certs/dh 1024',
             'creates' => '/etc/raddb/certs/dh',
             'path'    => '/usr/bin',
           )
-          .that_requires('File[/etc/raddb/certs]')
+          .that_requires('File[freeradius certs]')
       end
 
       it do
-        is_expected.to contain_exec('random')
+        is_expected.to contain_exec('freeradius random')
           .with(
             'command' => 'dd if=/dev/urandom of=/etc/raddb/certs/random count=10 >/dev/null 2>&1',
             'creates' => '/etc/raddb/certs/random',
             'path'    => '/bin',
           )
-          .that_requires('File[/etc/raddb/certs]')
+          .that_requires('File[freeradius certs]')
       end
 
       it do
@@ -362,11 +373,12 @@ describe 'freeradius' do
       end
 
       it do
-        [
-          '/etc/raddb/clients.conf',
-          '/etc/raddb/sql.conf',
-        ].each do |file|
-          is_expected.to contain_file(file)
+        {
+          'freeradius clients.conf': '/etc/raddb/clients.conf',
+          'freeradius sql.conf': '/etc/raddb/sql.conf',
+        }.each do |name, path|
+          is_expected.to contain_file(name)
+            .with_path(path)
             .with(
               'content' => '# FILE INTENTIONALLY BLANK',
               'group'   => 'radiusd',
@@ -388,6 +400,7 @@ describe 'freeradius' do
 
         it do
           is_expected.to contain_package('freeradius-mysql')
+            .with_name('freeradius-mysql')
             .with(
               'ensure' => 'installed',
             )
@@ -403,6 +416,7 @@ describe 'freeradius' do
 
         it do
           is_expected.to contain_package('freeradius-postgresql')
+            .with_name('freeradius-postgresql')
             .with(
               'ensure' => 'installed',
             )
@@ -418,6 +432,7 @@ describe 'freeradius' do
 
         it do
           is_expected.to contain_package('freeradius-perl')
+            .with_name('freeradius-perl')
             .with(
               'ensure' => 'installed',
             )
@@ -433,6 +448,7 @@ describe 'freeradius' do
 
         it do
           is_expected.to contain_package('freeradius-utils')
+            .with_name('freeradius-utils')
             .with(
               'ensure' => 'installed',
             )
@@ -448,6 +464,7 @@ describe 'freeradius' do
 
         it do
           is_expected.to contain_package('freeradius-ldap')
+            .with_name('freeradius-ldap')
             .with(
               'ensure' => 'installed',
             )
@@ -463,6 +480,7 @@ describe 'freeradius' do
 
         it do
           is_expected.to contain_package('freeradius-dhcp')
+            .with_name('freeradius-dhcp')
             .with(
               'ensure' => 'installed',
             )
@@ -478,6 +496,7 @@ describe 'freeradius' do
 
         it do
           is_expected.to contain_package('freeradius-krb5')
+            .with_name('freeradius-krb5')
             .with(
               'ensure' => 'installed',
             )
@@ -493,9 +512,9 @@ describe 'freeradius' do
 
         it do
           is_expected.to contain_package('wpa_supplicant')
+            .with_name('wpa_supplicant')
             .with(
               'ensure' => 'installed',
-              'name'   => 'wpa_supplicant',
             )
         end
       end

--- a/spec/classes/radsniff_spec.rb
+++ b/spec/classes/radsniff_spec.rb
@@ -52,7 +52,8 @@ describe 'freeradius::radsniff' do
       case os_facts[:osfamily]
       when 'RedHat'
         it do
-          is_expected.to contain_file('/etc/sysconfig/radsniff')
+          is_expected.to contain_file('freeradius radsniff envfile')
+            .with_path('/etc/sysconfig/radsniff')
             .with_content(%r{RADSNIFF_OPTIONS="radsniff cmd \\"line\\" options"})
             .that_notifies('Service[radsniff]')
             .that_requires('Package[freeradius-utils]')
@@ -67,7 +68,8 @@ describe 'freeradius::radsniff' do
         end
       when 'Debian'
         it do
-          is_expected.to contain_file('/etc/defaults/radsniff')
+          is_expected.to contain_file('freeradius radsniff envfile')
+            .with_path('/etc/defaults/radsniff')
             .with_content(%r{RADSNIFF_OPTIONS="radsniff cmd \\"line\\" options"})
             .that_notifies('Service[radsniff]')
             .that_requires('Package[freeradius-utils]')
@@ -104,7 +106,8 @@ describe 'freeradius::radsniff' do
         end
 
         it do
-          is_expected.to contain_file('/test/env/file')
+          is_expected.to contain_file('freeradius radsniff envfile')
+            .with_path('/test/env/file')
             .with_content(%r{RADSNIFF_OPTIONS="radsniff cmd \\"line\\" options"})
             .that_notifies('Service[radsniff]')
             .that_requires('Package[freeradius-utils]')

--- a/spec/defines/attr_spec.rb
+++ b/spec/defines/attr_spec.rb
@@ -12,7 +12,8 @@ describe 'freeradius::attr' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/mods-config/attr_filter/test')
+    is_expected.to contain_file('freeradius attr_filter/test')
+      .with_path('/etc/raddb/mods-config/attr_filter/test')
       .that_notifies('Service[radiusd]')
       .that_requires('Group[radiusd]')
       .that_requires('Package[freeradius]')
@@ -24,11 +25,11 @@ describe 'freeradius::attr' do
   end
 
   it do
-    is_expected.to contain_concat__fragment('attr-test')
+    is_expected.to contain_concat__fragment('freeradius attr-test')
       .with_content(%r{^attr_filter filter.test {\n\s+key = "\%{User-Name}"\n\s+filename = \${modconfdir}/\${\.:name}/test\n}})
       .without_content(%r{^\s+relaxed\s+.*$})
       .with_order('20')
-      .with_target('/etc/raddb/mods-available/attr_filter')
+      .with_target('freeradius mods-available/attr_filter')
   end
 
   context 'with relaxed = no' do
@@ -37,7 +38,7 @@ describe 'freeradius::attr' do
     end
 
     it do
-      is_expected.to contain_concat__fragment('attr-test')
+      is_expected.to contain_concat__fragment('freeradius attr-test')
         .with_content(%r{^\s+relaxed\s+=\s+no$})
     end
   end
@@ -48,7 +49,7 @@ describe 'freeradius::attr' do
     end
 
     it do
-      is_expected.to contain_concat__fragment('attr-test')
+      is_expected.to contain_concat__fragment('freeradius attr-test')
         .with_content(%r{^\s+relaxed\s+=\s+yes$})
     end
   end

--- a/spec/defines/blank_spec.rb
+++ b/spec/defines/blank_spec.rb
@@ -8,9 +8,10 @@ describe 'freeradius::blank' do
   let(:params) { {} }
 
   it do
-    is_expected.to contain_file('/etc/raddb/test')
+    is_expected.to contain_file('freeradius test')
+      .with_path('/etc/raddb/test')
       .that_notifies('Service[radiusd]')
-      .that_requires('File[/etc/raddb]')
+      .that_requires('File[freeradius raddb]')
       .that_requires('Group[radiusd]')
       .that_requires('Package[freeradius]')
       .with_content(%r{^# This file is intentionally left blank .*})

--- a/spec/defines/cert_spec.rb
+++ b/spec/defines/cert_spec.rb
@@ -14,9 +14,10 @@ describe 'freeradius::cert' do
     end
 
     it do
-      is_expected.to contain_file('/etc/raddb/certs/test')
+      is_expected.to contain_file('freeradius certs/test')
+        .with_path('/etc/raddb/certs/test')
         .that_notifies('Service[radiusd]')
-        .that_requires('File[/etc/raddb/certs]')
+        .that_requires('File[freeradius certs]')
         .that_requires('Group[radiusd]')
         .that_requires('Package[freeradius]')
         .with_content(%r{test data})
@@ -39,9 +40,9 @@ describe 'freeradius::cert' do
     end
 
     it do
-      is_expected.to contain_file('/etc/raddb/certs/test')
+      is_expected.to contain_file('freeradius certs/test')
         .that_notifies('Service[radiusd]')
-        .that_requires('File[/etc/raddb/certs]')
+        .that_requires('File[freeradius certs]')
         .that_requires('Group[radiusd]')
         .that_requires('Package[freeradius]')
         .with_content(nil)

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -14,14 +14,15 @@ describe 'freeradius::client' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/clients.d/test.conf')
+    is_expected.to contain_file('freeradius clients.d/test_short.conf')
+      .with_path('/etc/raddb/clients.d/test_short.conf')
       .with_content(%r{^client test_short {\n\s+ipaddr = 1.2.3.4\n\s+proto = \*\n\s+shortname = test_short\n\s+secret = "secret_value"\n\s+require_message_authenticator = no\n}\n})
       .with_ensure('present')
       .with_group('radiusd')
       .with_mode('0640')
       .with_owner('root')
       .that_notifies('Service[radiusd]')
-      .that_requires('File[/etc/raddb/clients.d]')
+      .that_requires('File[freeradius clients.d]')
       .that_requires('Group[radiusd]')
   end
 
@@ -57,7 +58,7 @@ describe 'freeradius::client' do
     end
 
     it do
-      is_expected.to contain_file('/etc/raddb/clients.d/test.conf')
+      is_expected.to contain_file('freeradius clients.d/test_short.conf')
         .with_content(%r{^\s+password = "foo bar"$})
     end
   end

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -12,7 +12,8 @@ describe 'freeradius::config' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/mods-config/test')
+    is_expected.to contain_file('freeradius mods-config/test')
+      .with_path('/etc/raddb/mods-config/test')
       .with_content('test content')
       .with_ensure('present')
       .with_group('radiusd')

--- a/spec/defines/dictionary_spec.rb
+++ b/spec/defines/dictionary_spec.rb
@@ -12,14 +12,15 @@ describe 'freeradius::dictionary' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/dictionary.d/dictionary.test')
+    is_expected.to contain_file('freeradius dictionary.d/dictionary.test')
+      .with_path('/etc/raddb/dictionary.d/dictionary.test')
       .with_ensure('present')
       .with_group('radiusd')
       .with_mode('0644')
       .with_owner('root')
       .with_source('puppet:///modules/test/path/to/dict')
       .that_notifies('Service[radiusd]')
-      .that_requires('File[/etc/raddb/dictionary.d]')
+      .that_requires('File[freeradius dictionary.d]')
       .that_requires('Package[freeradius]')
       .that_requires('Group[radiusd]')
   end
@@ -28,7 +29,7 @@ describe 'freeradius::dictionary' do
     is_expected.to contain_concat__fragment('dictionary.test')
       .with_content(%r{^\$INCLUDE /etc/raddb/dictionary\.d/dictionary\.test$})
       .with_order('50')
-      .with_target('/etc/raddb/dictionary')
-      .that_requires('File[/etc/raddb/dictionary.d/dictionary.test]')
+      .with_target('freeradius dictionary')
+      .that_requires('File[freeradius dictionary.d/dictionary.test]')
   end
 end

--- a/spec/defines/home_server_pool_spec.rb
+++ b/spec/defines/home_server_pool_spec.rb
@@ -18,6 +18,6 @@ describe 'freeradius::home_server_pool' do
     is_expected.to contain_concat__fragment('homeserverpool-test')
       .with_content(%r{home_server_pool test {\n\s+type = fail-over\n\s+home_server = test_home_server_1\n\s+home_server = test_home_server_2\n}\n})
       .with_order('20')
-      .with_target('/etc/raddb/proxy.conf')
+      .with_target('freeradius proxy.conf')
   end
 end

--- a/spec/defines/home_server_spec.rb
+++ b/spec/defines/home_server_spec.rb
@@ -16,7 +16,7 @@ describe 'freeradius::home_server' do
     is_expected.to contain_concat__fragment('homeserver-test')
       .with_content(%r{home_server test {\n\s+type = auth\n\s+ipaddr = 1.2.3.4\n\s+port = 1812\n\s+proto = udp\n\s+secret = "test_secret"\n\s+status_check = none\n}\n})
       .with_order('10')
-      .with_target('/etc/raddb/proxy.conf')
+      .with_target('freeradius proxy.conf')
   end
 
   context 'with secret containing a newline' do

--- a/spec/defines/instantiate_spec.rb
+++ b/spec/defines/instantiate_spec.rb
@@ -8,7 +8,8 @@ describe 'freeradius::instantiate' do
   let(:params) { {} }
 
   it do
-    is_expected.to contain_file('/etc/raddb/instantiate/test')
+    is_expected.to contain_file('freeradius instantiate/test')
+      .with_path('/etc/raddb/instantiate/test')
       .with_content('test')
       .with_ensure('present')
       .with_group('radiusd')

--- a/spec/defines/krb5_spec.rb
+++ b/spec/defines/krb5_spec.rb
@@ -13,7 +13,8 @@ describe 'freeradius::krb5' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/mods-available/test')
+    is_expected.to contain_file('freeradius mods-available/test')
+      .with_path('/etc/raddb/mods-available/test')
       .with_content(%r{^\s+keytab = test_keytab$})
       .with_content(%r{^\s+service_principal = test_principal$})
       .with_ensure('present')
@@ -26,7 +27,8 @@ describe 'freeradius::krb5' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/mods-enabled/test')
+    is_expected.to contain_file('freeradius mods-enabled/test')
+      .with_path('/etc/raddb/mods-enabled/test')
       .with_ensure('link')
       .with_target('../mods-available/test')
   end

--- a/spec/defines/module/ldap_spec.rb
+++ b/spec/defines/module/ldap_spec.rb
@@ -27,7 +27,8 @@ describe 'freeradius::module::ldap' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/mods-available/test')
+    is_expected.to contain_file('freeradius mods-available/test')
+      .with_path('/etc/raddb/mods-available/test')
       .with_content(%r{^ldap test \{\n})
       .with_content(%r{^\s+server = 'localhost'\n})
       .with_content(%r{^\s+identity = 'cn=root,dc=example,dc=com'\n})
@@ -45,7 +46,8 @@ describe 'freeradius::module::ldap' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/mods-enabled/test')
+    is_expected.to contain_file('freeradius mods-enabled/test')
+      .with_path('/etc/raddb/mods-enabled/test')
       .with_ensure('link')
       .with_target('../mods-available/test')
   end
@@ -64,7 +66,7 @@ describe 'freeradius::module::ldap' do
     end
 
     it do
-      is_expected.to contain_file('/etc/raddb/mods-available/test')
+      is_expected.to contain_file('freeradius mods-available/test')
         .with_content(%r{^\s+connect_timeout = 3.0})
         .with_content(%r{^\s+use_referral_credentials = no})
         .without_content(%r{^\s+session_tracking = .*})
@@ -80,7 +82,7 @@ describe 'freeradius::module::ldap' do
       end
 
       it do
-        is_expected.to contain_file('/etc/raddb/mods-available/test')
+        is_expected.to contain_file('freeradius mods-available/test')
           .with_content(%r{^\s+connect_timeout = 5.0})
           .with_content(%r{^\s+use_referral_credentials = yes})
           .with_content(%r{^\s+session_tracking = yes})
@@ -159,7 +161,7 @@ describe 'freeradius::module::ldap' do
     end
 
     it do
-      is_expected.to contain_file('/etc/raddb/mods-available/test')
+      is_expected.to contain_file('freeradius mods-available/test')
         .with_content(%r{^\s+update \{\n\s+control:Password-With-Header	\+= 'userPassword'\n\s+reply:Framed-IP-Address := 'radiusFramedIPAddress'\n\s+\}\n})
     end
   end

--- a/spec/defines/module_spec.rb
+++ b/spec/defines/module_spec.rb
@@ -12,7 +12,8 @@ describe 'freeradius::module' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/mods-available/test')
+    is_expected.to contain_file('freeradius mods-available/test')
+      .with_path('/etc/raddb/mods-available/test')
       .with_content(nil)
       .with_ensure('present')
       .with_group('radiusd')
@@ -25,7 +26,8 @@ describe 'freeradius::module' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/mods-enabled/test')
+    is_expected.to contain_file('freeradius mods-enabled/test')
+      .with_path('/etc/raddb/mods-enabled/test')
       .with_ensure('link')
       .with_target('../mods-available/test')
   end

--- a/spec/defines/policy_spec.rb
+++ b/spec/defines/policy_spec.rb
@@ -12,7 +12,8 @@ describe 'freeradius::policy' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/policy.d/test')
+    is_expected.to contain_file('freeradius policy.d/test')
+      .with_path('/etc/raddb/policy.d/test')
       .with_ensure('present')
       .with_group('radiusd')
       .with_mode('0644')
@@ -24,10 +25,10 @@ describe 'freeradius::policy' do
   end
 
   it do
-    is_expected.to contain_concat__fragment('policy-test')
+    is_expected.to contain_concat__fragment('freeradius policy-test')
       .with_content(%r{\s+\$INCLUDE /etc/raddb/policy.d/test$})
       .with_order('50')
-      .with_target('/etc/raddb/policy.conf')
-      .that_requires('File[/etc/raddb/policy.d/test]')
+      .with_target('freeradius policy.conf')
+      .that_requires('File[freeradius policy.d/test]')
   end
 end

--- a/spec/defines/realm_spec.rb
+++ b/spec/defines/realm_spec.rb
@@ -13,9 +13,9 @@ describe 'freeradius::realm' do
   end
 
   it do
-    is_expected.to contain_concat__fragment('realm-test')
+    is_expected.to contain_concat__fragment('freeradius realm-test')
       .with_content(%r{^realm test {\n\s+virtual_server = test_virtual_server\n\s+pool = test_pool\n}})
       .with_order('30')
-      .with_target('/etc/raddb/proxy.conf')
+      .with_target('freeradius proxy.conf')
   end
 end

--- a/spec/defines/script_spec.rb
+++ b/spec/defines/script_spec.rb
@@ -12,7 +12,8 @@ describe 'freeradius::script' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/scripts/test')
+    is_expected.to contain_file('freeradius scripts/test')
+      .with_path('/etc/raddb/scripts/test')
       .with_ensure('present')
       .with_group('radiusd')
       .with_mode('0750')
@@ -21,6 +22,6 @@ describe 'freeradius::script' do
       .that_notifies('Service[radiusd]')
       .that_requires('Package[freeradius]')
       .that_requires('Group[radiusd]')
-      .that_requires('File[/etc/raddb/scripts]')
+      .that_requires('File[freeradius scripts]')
   end
 end

--- a/spec/defines/site_spec.rb
+++ b/spec/defines/site_spec.rb
@@ -12,7 +12,8 @@ describe 'freeradius::site' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/sites-available/test')
+    is_expected.to contain_file('freeradius sites-available/test')
+      .with_path('/etc/raddb/sites-available/test')
       .with_content(nil)
       .with_ensure('present')
       .with_group('radiusd')
@@ -25,7 +26,8 @@ describe 'freeradius::site' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/sites-enabled/test')
+    is_expected.to contain_file('freeradius sites-enabled/test')
+      .with_path('/etc/raddb/sites-enabled/test')
       .with_ensure('link')
       .with_target('/etc/raddb/sites-available/test')
   end

--- a/spec/defines/sql_spec.rb
+++ b/spec/defines/sql_spec.rb
@@ -22,7 +22,8 @@ describe 'freeradius::sql' do
       end
 
       it do
-        is_expected.to contain_file('/etc/raddb/mods-available/test')
+        is_expected.to contain_file('freeradius mods-available/test')
+          .with_path('/etc/raddb/mods-available/test')
           .with_content(%r{^sql test \{\n})
           .with_content(%r{^\s+dialect = "postgresql"$})
           .with_content(%r{^\s+server = "localhost"$})
@@ -42,7 +43,8 @@ describe 'freeradius::sql' do
       end
 
       it do
-        is_expected.to contain_file('/etc/raddb/mods-enabled/test')
+        is_expected.to contain_file('freeradius mods-enabled/test')
+          .with_path('/etc/raddb/mods-enabled/test')
           .with_ensure('link')
           .with_target('../mods-available/test')
       end
@@ -55,7 +57,7 @@ describe 'freeradius::sql' do
         end
 
         it do
-          is_expected.to contain_file('/etc/raddb/mods-available/test')
+          is_expected.to contain_file('freeradius mods-available/test')
             .with_content(%r{^\s+logfile = \${logdir}/sqllog.sql$})
         end
 
@@ -98,7 +100,7 @@ describe 'freeradius::sql' do
         end
 
         it do
-          is_expected.to contain_file('/etc/raddb/mods-available/test')
+          is_expected.to contain_file('freeradius mods-available/test')
             .with_content(%r{^\s+connect_timeout = 3.0})
         end
 
@@ -110,7 +112,7 @@ describe 'freeradius::sql' do
           end
 
           it do
-            is_expected.to contain_file('/etc/raddb/mods-available/test')
+            is_expected.to contain_file('freeradius mods-available/test')
               .with_content(%r{^\s+connect_timeout = 5.0})
           end
 

--- a/spec/defines/statusclient_spec.rb
+++ b/spec/defines/statusclient_spec.rb
@@ -13,7 +13,8 @@ describe 'freeradius::statusclient' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/statusclients.d/test.conf')
+    is_expected.to contain_file('freeradius statusclients.d/test.conf')
+      .with_path('/etc/raddb/statusclients.d/test.conf')
       .with_content(%r{^client test {\n\s+ipaddr = 1.2.3.4\n\s+shortname = test\n\s+secret = "test_secret"\n}\n})
       .with_ensure('present')
       .with_group('radiusd')
@@ -22,7 +23,7 @@ describe 'freeradius::statusclient' do
       .that_notifies('Service[radiusd]')
       .that_requires('Package[freeradius]')
       .that_requires('Group[radiusd]')
-      .that_requires('File[/etc/raddb/clients.d]')
+      .that_requires('File[freeradius clients.d]')
   end
 
   context 'with secret containing a newline' do

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -75,12 +75,12 @@ shared_context 'redhat_common_dependencies' do
       "package { 'freeradius': }",
       "group { 'radiusd': }",
       "service { 'radiusd': }",
-      "file { '/etc/raddb': ensure => directory }",
-      "file { '/etc/raddb/certs': ensure => directory }",
-      "file { '/etc/raddb/clients.d': ensure => directory }",
-      "file { '/etc/raddb/dictionary.d': ensure => directory }",
-      "file { '/etc/raddb/mods-config': ensure => directory }",
-      "file { '/etc/raddb/scripts': ensure => directory }",
+      "file { 'freeradius raddb': ensure => directory, path => '/etc/raddb/raddb' }",
+      "file { 'freeradius certs': ensure => directory, path => '/etc/raddb/certs' }",
+      "file { 'freeradius clients.d': ensure => directory, path => '/etc/raddb/clients.d' }",
+      "file { 'freeradius dictionary.d': ensure => directory, path => '/etc/raddb/dictionary.d' }",
+      "file { 'freeradius mods-config': ensure => directory, path => '/etc/raddb/mods-config' }",
+      "file { 'freeradius scripts': ensure => directory, path => '/etc/raddb/scripts' }",
     ]
   end
 end


### PR DESCRIPTION
This is a big commit - basically a big manual search and replace, adding `freeradius` rather than `/etc/raddb` (well, `$fr_basepath`etc.) in resource names. Additionally, group, user, service, package etc. are all updated to have a common title, and a name parameter for the os-specific value.

This enables us to update the tests to work with other OSes - right now the tests are all assuming RedHat which is not ideal.

Specs updated and passing.
PDK validations for modified bits of code resolved.

Resolves #183 