### PR TITLE
bump for stdlib 9

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,27 +1,27 @@
 # Base class to install FreeRADIUS
 class freeradius (
-  Boolean $control_socket          = false,
-  Integer $max_servers             = 4096,
-  Integer $max_requests            = 4096,
-  Integer $max_request_time        = 30,
-  Boolean $mysql_support           = false,
-  Boolean $pgsql_support           = false,
-  Boolean $perl_support            = false,
-  Boolean $utils_support           = false,
-  Boolean $ldap_support            = false,
-  Boolean $dhcp_support            = false,
-  Boolean $krb5_support            = false,
-  Boolean $wpa_supplicant          = false,
-  Boolean $winbind_support         = false,
-  String $log_destination          = 'files',
-  Boolean $syslog                  = false,
-  String $syslog_facility          = 'daemon',
-  Freeradius::Boolean $log_auth    = 'no',
-  Boolean $preserve_mods           = true,
-  Boolean $correct_escapes         = true,
-  Boolean $manage_logpath          = true,
-  Optional[String] $package_ensure = 'installed',
-  String $radacctdir               = $freeradius::params::radacctdir,
+  Boolean $control_socket                                      = false,
+  Integer $max_servers                                         = 4096,
+  Integer $max_requests                                        = 4096,
+  Integer $max_request_time                                    = 30,
+  Boolean $mysql_support                                       = false,
+  Boolean $pgsql_support                                       = false,
+  Boolean $perl_support                                        = false,
+  Boolean $utils_support                                       = false,
+  Boolean $ldap_support                                        = false,
+  Boolean $dhcp_support                                        = false,
+  Boolean $krb5_support                                        = false,
+  Boolean $wpa_supplicant                                      = false,
+  Boolean $winbind_support                                     = false,
+  Enum['files', 'syslog', 'stdout', 'stderr'] $log_destination = 'files',
+  Boolean $syslog                                              = false,
+  String $syslog_facility                                      = 'daemon',
+  Freeradius::Boolean $log_auth                                = 'no',
+  Boolean $preserve_mods                                       = true,
+  Boolean $correct_escapes                                     = true,
+  Boolean $manage_logpath                                      = true,
+  Optional[String] $package_ensure                             = 'installed',
+  String $radacctdir                                           = $freeradius::params::radacctdir,
 ) inherits freeradius::params {
   if $freeradius::fr_version !~ /^3/ {
     notify { 'This module is only compatible with FreeRADIUS 3.': }
@@ -36,9 +36,6 @@ class freeradius (
   } else {
     $fr_3_1 = false
   }
-
-  validate_re($log_destination, '^(files|syslog|stdout|stderr)$',
-    "log_destination value (${log_destination}) is not a valid value")
 
   if $control_socket == true {
     warning(@(WARN/L)

--- a/manifests/module/detail.pp
+++ b/manifests/module/detail.pp
@@ -9,12 +9,8 @@ define freeradius::module::detail (
   String $header                                   = '%t',
   Optional[Freeradius::Boolean] $locking           = undef,
   Optional[Freeradius::Boolean] $log_packet_header = undef,
-  Array[String] $suppress                          = [],
+  Optional[Array[String]] $suppress                = [],
 ) {
-  if $suppress {
-    validate_array($suppress)
-  }
-
   freeradius::module { "detail.${name}":
     ensure  => $ensure,
     content => template('freeradius/detail.erb'),

--- a/manifests/sql.pp
+++ b/manifests/sql.pp
@@ -2,36 +2,36 @@
 define freeradius::sql (
   Enum['mysql', 'mssql', 'oracle', 'postgresql'] $database,
   Freeradius::Password $password,
-  Optional[String] $server                       = 'localhost',
-  Optional[String] $login                        = 'radius',
-  Optional[String] $radius_db                    = 'radius',
-  Freeradius::Integer $num_sql_socks             = "\${thread[pool].max_servers}",
-  Optional[String] $query_file                   = "\${modconfdir}/\${.:name}/main/\${dialect}/queries.conf",
-  Optional[String] $custom_query_file            = undef,
-  Optional[Integer] $lifetime                    = 0,
-  Optional[Integer] $max_queries                 = 0,
-  Freeradius::Ensure $ensure                     = present,
-  Optional[String] $acct_table1                  = 'radacct',
-  Optional[String] $acct_table2                  = 'radacct',
-  Optional[String] $postauth_table               = 'radpostauth',
-  Optional[String] $authcheck_table              = 'radcheck',
-  Optional[String] $authreply_table              = 'radreply',
-  Optional[String] $groupcheck_table             = 'radgroupcheck',
-  Optional[String] $groupreply_table             = 'radgroupreply',
-  Optional[String] $usergroup_table              = 'radusergroup',
-  Freeradius::Boolean $deletestalesessions       = 'yes',
-  Freeradius::Boolean $sqltrace                  = 'no',
-  Optional[String] $sqltracefile                 = "\${logdir}/sqllog.sql",
-  Optional[Integer] $connect_failure_retry_delay = 60,
-  Optional[String] $nas_table                    = 'nas',
-  Freeradius::Boolean $read_groups               = 'yes',
-  Optional[Integer] $port                        = 3306,
-  Freeradius::Boolean $readclients               = 'no',
-  Optional[Integer] $pool_start                  = 1,
-  Optional[Integer] $pool_min                    = 1,
-  Optional[Integer] $pool_spare                  = 1,
-  Optional[Integer] $pool_idle_timeout           = 60,
-  Optional[Float] $pool_connect_timeout          = undef,
+  Variant[Stdlib::Host, Stdlib::IP::Address] $server                                = 'localhost',
+  Optional[String] $login                                                           = 'radius',
+  Optional[String] $radius_db                                                       = 'radius',
+  Variant[Freeradius::Integer, Enum["\${thread[pool].max_servers}"]] $num_sql_socks = "\${thread[pool].max_servers}",
+  Optional[String] $query_file                                                      = "\${modconfdir}/\${.:name}/main/\${dialect}/queries.conf",
+  Optional[String] $custom_query_file                                               = undef,
+  Optional[Integer] $lifetime                                                       = 0,
+  Optional[Integer] $max_queries                                                    = 0,
+  Freeradius::Ensure $ensure                                                        = present,
+  Optional[String] $acct_table1                                                     = 'radacct',
+  Optional[String] $acct_table2                                                     = 'radacct',
+  Optional[String] $postauth_table                                                  = 'radpostauth',
+  Optional[String] $authcheck_table                                                 = 'radcheck',
+  Optional[String] $authreply_table                                                 = 'radreply',
+  Optional[String] $groupcheck_table                                                = 'radgroupcheck',
+  Optional[String] $groupreply_table                                                = 'radgroupreply',
+  Optional[String] $usergroup_table                                                 = 'radusergroup',
+  Freeradius::Boolean $deletestalesessions                                          = 'yes',
+  Freeradius::Boolean $sqltrace                                                     = 'no',
+  Optional[String] $sqltracefile                                                    = "\${logdir}/sqllog.sql",
+  Optional[Integer] $connect_failure_retry_delay                                    = 60,
+  Optional[String] $nas_table                                                       = 'nas',
+  Freeradius::Boolean $read_groups                                                  = 'yes',
+  Optional[Integer] $port                                                           = 3306,
+  Freeradius::Boolean $readclients                                                  = 'no',
+  Optional[Integer] $pool_start                                                     = 1,
+  Optional[Integer] $pool_min                                                       = 1,
+  Optional[Integer] $pool_spare                                                     = 1,
+  Optional[Integer] $pool_idle_timeout                                              = 60,
+  Optional[Float] $pool_connect_timeout                                             = undef,
 ) {
   $fr_package          = $::freeradius::params::fr_package
   $fr_service          = $::freeradius::params::fr_service
@@ -40,17 +40,6 @@ define freeradius::sql (
   $fr_group            = $::freeradius::params::fr_group
   $fr_logpath          = $::freeradius::params::fr_logpath
   $fr_moduleconfigpath = $::freeradius::params::fr_moduleconfigpath
-
-  # Validate our inputs
-  # Hostnames
-  unless (is_domain_name($server) or is_ip_address($server)) {
-    fail('$server must be a valid hostname or IP address')
-  }
-
-  # Validate integers
-  unless is_integer($num_sql_socks) or $num_sql_socks == "\${thread[pool].max_servers}" {
-    fail('$num_sql_socks must be an integer')
-  }
 
   # Warn if the user tries to set a FreeRADIUS 3.1.x specific parameter, and
   # we detect that they are not on (or not installing) a FreeRADIUS 3.1.x

--- a/manifests/virtual_module.pp
+++ b/manifests/virtual_module.pp
@@ -1,6 +1,6 @@
 # Define a virtual module, made up of others
 define freeradius::virtual_module (
-  Array[String] $submodules,
+  Array[String, 1] $submodules,
   Freeradius::Ensure $ensure = present,
   Enum['redundant','load-balance','redundant-load-balance','group'] $type = 'redundant-load-balance',
   ) {
@@ -8,12 +8,6 @@ define freeradius::virtual_module (
   $fr_service  = $::freeradius::params::fr_service
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
-
-  # Make sure $submodules is a non-zero array
-  validate_array($submodules)
-  if count($submodules) < 1 {
-    fail('Must specify at least one $submodule')
-  }
 
   file { "${fr_basepath}/instantiate/${name}":
     ensure  => $ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.0.0 <7.0.0"
+      "version_requirement": ">=4.0.0 <10.0.0"
     },
     {
       "name": "puppetlabs/firewall",


### PR DESCRIPTION
replaces usage of old validation_()-functions with proper type-definition and therefore allows the usage of `puppet-stdlib` 9.0.0.

Bonus: also fixes the CI ;)