### PR TITLE
Make devcontainer work on non-x86_64

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM puppet/pdk:latest
+FROM --platform=x86_64 puppet/pdk:latest
 
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
I am on an arm Mac, so have to have this in the Dockerfile to make vscode play nice - as pdk containers only ship for x86_64.