### PR TITLE
Use name instead of shortname for client definition

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -42,7 +42,7 @@ define freeradius::client (
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
-  file { "${fr_basepath}/clients.d/${shortname}.conf":
+  file { "${fr_basepath}/clients.d/${name}.conf":
     ensure  => $ensure,
     mode    => '0640',
     owner   => 'root',
@@ -61,14 +61,14 @@ define freeradius::client (
 
     if $port {
       if $ip {
-        firewall { "100 ${shortname} ${port_description} v4":
+        firewall { "100 ${name} ${port_description} v4":
           proto  => 'udp',
           dport  => $port,
           action => 'accept',
           source => $ip,
         }
       } elsif $ip6 {
-        firewall { "100 ${shortname} ${port_description} v6":
+        firewall { "100 ${name} ${port_description} v6":
           proto    => 'udp',
           dport    => $port,
           action   => 'accept',
@@ -83,7 +83,7 @@ define freeradius::client (
 
   if $huntgroups {
     $huntgroups.each |$index, $huntgroup| {
-      freeradius::huntgroup { "huntgroup.client.${shortname}.${index}":
+      freeradius::huntgroup { "huntgroup.client.${name}.${index}":
         * => $huntgroup
       }
     }

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -14,7 +14,7 @@ describe 'freeradius::client' do
   end
 
   it do
-    is_expected.to contain_file('/etc/raddb/clients.d/test_short.conf')
+    is_expected.to contain_file('/etc/raddb/clients.d/test.conf')
       .with_content(%r{^client test_short {\n\s+ipaddr = 1.2.3.4\n\s+proto = \*\n\s+shortname = test_short\n\s+secret = "secret_value"\n\s+require_message_authenticator = no\n}\n})
       .with_ensure('present')
       .with_group('radiusd')
@@ -57,7 +57,7 @@ describe 'freeradius::client' do
     end
 
     it do
-      is_expected.to contain_file('/etc/raddb/clients.d/test_short.conf')
+      is_expected.to contain_file('/etc/raddb/clients.d/test.conf')
         .with_content(%r{^\s+password = "foo bar"$})
     end
   end
@@ -81,7 +81,7 @@ describe 'freeradius::client' do
       end
 
       it do
-        is_expected.to contain_firewall('100 test_short 1234 v4')
+        is_expected.to contain_firewall('100 test 1234 v4')
           .with_proto('udp')
           .with_dport(1234)
           .with_action('accept')
@@ -96,9 +96,9 @@ describe 'freeradius::client' do
         end
 
         it do
-          is_expected.not_to contain_firewall('100 test_short 1234 v4')
+          is_expected.not_to contain_firewall('100 test 1234 v4')
 
-          is_expected.to contain_firewall('100 test_short 1234 v6')
+          is_expected.to contain_firewall('100 test 1234 v6')
             .with_proto('udp')
             .with_dport(1234)
             .with_action('accept')
@@ -116,7 +116,7 @@ describe 'freeradius::client' do
       end
 
       it do
-        is_expected.to contain_firewall('100 test_short 1234,4321 v4')
+        is_expected.to contain_firewall('100 test 1234,4321 v4')
           .with_proto('udp')
           .with_dport([1234, 4321])
           .with_action('accept')
@@ -131,9 +131,9 @@ describe 'freeradius::client' do
         end
 
         it do
-          is_expected.not_to contain_firewall('100 test_short 1234,4321 v4')
+          is_expected.not_to contain_firewall('100 test 1234,4321 v4')
 
-          is_expected.to contain_firewall('100 test_short 1234,4321 v6')
+          is_expected.to contain_firewall('100 test 1234,4321 v6')
             .with_proto('udp')
             .with_dport([1234, 4321])
             .with_action('accept')


### PR DESCRIPTION
#### Pull Request (PR) description
Use name instead of shortname in client definition for filename, firewall rule and huntgroup to allow the same shortname for different clients.

#### This Pull Request (PR) fixes the following issues
In some setups it may be needed that a client must be published multiple times with different ip addresses. In 1.x it was possible since it the client "name" was the IP itself. For 2.x the client "name" is now the `shortname` but there exist no definition that it needs to be uniq as far as we could found.