### PR TITLE
Update to latest GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
     - name: Get latest tag
       id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF:10}
+      run: echo "{tag}=${GITHUB_REF:10}" >> $GITHUB_OUTPUT
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ steps.vars.outputs.tag }}
     - name: Build and publish module
-      uses: barnumbirr/action-forge-publish@v2.8.0
+      uses: barnumbirr/action-forge-publish@v2
       env:
        FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
        REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run unit tests
       uses: puppets-epic-show-theatre/action-pdk-test-unit@v1
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run PDK validate
       uses: puppets-epic-show-theatre/action-pdk-validate@v1


### PR DESCRIPTION
Update to latest versions of the GitHub Actions we rely on, and in some cases specify only the major release so we will track minor versions every run.

If this PR passes its pipeline, it's safe to merge. We won't be able to fully test the `barnumbirr/action-forge-publish` action until we come to publish our next release, but that's a job for another day.