### PR TITLE
Allow puppet 8, require puppet 7, update module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">=1.0.0 <3.0.0"
+      "version_requirement": ">=1.0.0 <7.0.0"
     },
     {
       "name": "saz/rsyslog",
@@ -22,15 +22,15 @@
     },
     {
       "name": "puppet/logrotate",
-      "version_requirement": ">=1.4.0 <4.0.0"
+      "version_requirement": ">=1.4.0 <8.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=1.0.0 <7.0.0"
+      "version_requirement": ">=1.0.0 <10.0.0"
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">=3.0.0 <5.0.0"
+      "version_requirement": ">=3.0.0 <6.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -92,7 +92,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.0.0 <7.0.0"
+      "version_requirement": ">=7.0.0 <9.0.0"
     }
   ],
   "pdk-version": "3.0.0",


### PR DESCRIPTION
Allow puppet 8.
Require puppet 7, following the least of stdlib and others which require 7 as a minimum.
Update the highest version of modules we require to allow the current versions of various modules.