### PR TITLE
Fix params_empty_string_assignment of freeradius::radsniff::options

### DIFF
--- a/manifests/radsniff.pp
+++ b/manifests/radsniff.pp
@@ -4,40 +4,22 @@
 # @param options commandline options passed to radsniff when it runs
 # @param
 class freeradius::radsniff (
-  Optional[String] $envfile = undef,
-  String $options = '',
-  Optional[String] $pidfile = undef,
+  String $envfile = $freeradius::params::fr_radsniff_envfile,
+  Optional[String] $options = undef,
+  String $pidfile = $freeradius::params::fr_radsniff_pidfile,
 ) inherits freeradius::params {
   unless $::freeradius::utils_support {
     fail('freeradius::radsniff requires freeradius have utils_support enabled')
   }
 
-  # Calculate the envfile to use - specified, then calculated, then error if none
-  if $envfile {
-    $final_envfile = $envfile
-  } else {
-    if $freeradius::radsniff::fr_radsniff_envfile {
-      $final_envfile = $freeradius::radsniff::fr_radsniff_envfile
-    } else {
-      fail('freeradius::radsniff requires envfile to be explicitly set on this OS')
-    }
+  $escaped_cmd = $options ? {
+    String[1] => $options.regsubst('"','\\\\"','G'),
+    default   => '',
   }
-
-  # Calculate the pidfile to use - specified, then calculated, then error if none
-  if $pidfile {
-    $final_pidfile = $pidfile
-  } else {
-    if $freeradius::radsniff::fr_radsniff_pidfile {
-      $final_pidfile = $freeradius::radsniff::fr_radsniff_pidfile
-    } else {
-      fail('freeradius::radsniff requires pidfile to be explicitly set on this OS')
-    }
-  }
-
-  $escaped_cmd = $options.regsubst('"','\\\\"','G')
 
   file { 'freeradius radsniff envfile':
-    path    => $final_envfile,
+    ensure  => file,
+    path    => $envfile,
     content => @("SYSCONFIG"),
       RADSNIFF_OPTIONS="${escaped_cmd}"
       | SYSCONFIG

--- a/templates/radsniff.service.erb
+++ b/templates/radsniff.service.erb
@@ -5,9 +5,9 @@ After=radiusd.target
 
 [Service]
 Type=forking
-PIDFile=<%=scope['::freeradius::radsniff::final_pidfile']%>
-EnvironmentFile=<%=scope['::freeradius::radsniff::final_envfile']%>
-ExecStart=/usr/bin/radsniff -P <%=scope['::freeradius::radsniff::final_pidfile']%> -d <%=scope['::freeradius::radsniff::fr_basepath']%> $RADSNIFF_OPTIONS
+PIDFile=<%= @pidfile %>
+EnvironmentFile=<%= @envfile %>
+ExecStart=/usr/bin/radsniff -P <%= @pidfile %> -d <%= @fr_basepath %> $RADSNIFF_OPTIONS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#### Pull Request (PR) description
* Fix params_empty_string_assignment of freeradius::radsniff::options
* Removes useless "Calculating" definitions
** Puppet itself fail with wrong parameter type (undef != String) if no value comes has been provided via class call or from params. The default lookup order is parameter from class call, hiera lookup and then default class value what is here the params value.

#### This Pull Request (PR) fixes the following issues
None