### PR TITLE
Fix link target for sites-enabled

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -43,6 +43,6 @@ define freeradius::site (
   file { "freeradius sites-enabled/${name}":
     ensure => $ensure_link,
     path   => "${fr_basepath}/sites-enabled/${name}",
-    target => "${fr_basepath}/sites-available/${name}",
+    target => "../sites-available/${name}",
   }
 }

--- a/spec/defines/site_spec.rb
+++ b/spec/defines/site_spec.rb
@@ -29,6 +29,6 @@ describe 'freeradius::site' do
     is_expected.to contain_file('freeradius sites-enabled/test')
       .with_path('/etc/raddb/sites-enabled/test')
       .with_ensure('link')
-      .with_target('/etc/raddb/sites-available/test')
+      .with_target('../sites-available/test')
   end
 end


### PR DESCRIPTION
The sites-enabled links point to an absolute path, while mods-enabled are relative. This updates sites-enabled links to follow the same pattern.