### PR TITLE
Fix locking in freeradius::module::detail

### DIFF
--- a/templates/detail.erb
+++ b/templates/detail.erb
@@ -87,7 +87,7 @@ detail <%= @name %> {
 	#
 #	locking = yes
 <%- if @locking -%>
-	locking = <%= @locking == true %>
+	locking = <%= @locking %>
 <%- end -%>
 
 	#


### PR DESCRIPTION
The locking parameter is a Enum['no', 'yes'], so it can't be checked  neither assigned as a boolean. The assignment must be to the value of the parameter, if present.