### PR TITLE
Individual SNMP trap enabling

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class freeradius (
   Boolean $manage_logpath                                      = true,
   Optional[String] $package_ensure                             = 'installed',
   String $radacctdir                                           = $freeradius::params::radacctdir,
-  Array $snmp_traps                                            = ['home_server_alive'],
+  Array $snmp_traps                                            = [],
 ) inherits freeradius::params {
   if $freeradius::fr_version !~ /^3/ {
     notify { 'This module is only compatible with FreeRADIUS 3.': }
@@ -158,7 +158,33 @@ class freeradius (
       preserve => true,
     }
   }
-
+  if empty($snmp_traps) {
+    $snmp_traps = [
+      'server_start',
+      'server_stop',
+      'server_max_requests',
+      'server_client_add',
+      'server_signal_hup',
+      'server_signal_term',
+      'server_thread_start',
+      'server_thread_stop',
+      'server_thread_Unresponsive',
+      'server_thread_max_threads',
+      'home_server_alive',
+      'home_server_zombie',
+      'home_server_dead',
+      'home_server_pool_normal',
+      'home_server_pool_fallback',
+      'server_files_module_hup',
+      'server_ldap_module_connection_up',
+      'server_ldap_module_connection_down',
+      'server_ldap_module_hup',
+      'server_sql_module_connection_up',
+      'server_sql_module_connection_close',
+      'server_sql_module_connection_fail',
+      'server_sql_module_hup',
+    ]
+  }
   # Add trigger.conf snmp trap configuration 
   file { "${freeradius::fr_basepath}/trigger.conf":
     ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,9 @@ class freeradius (
   Boolean $manage_logpath                                      = true,
   Optional[String] $package_ensure                             = 'installed',
   String $radacctdir                                           = $freeradius::params::radacctdir,
+  String $snmp_traps_enable                                    = 'disable',
+  String $snmp_traps_community                                 = 'public',
+  String $snmp_traps_dest                                      = '127.0.0.1',
   Array $snmp_traps                                            = [],
 ) inherits freeradius::params {
   if $freeradius::fr_version !~ /^3/ {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class freeradius (
   String $snmp_traps_enable                                    = 'disable',
   String $snmp_traps_community                                 = 'public',
   String $snmp_traps_dest                                      = '127.0.0.1',
-  Array $snmp_traps                                            = [],
+  Array $snmp_traps                                            = undef,
 ) inherits freeradius::params {
   if $freeradius::fr_version !~ /^3/ {
     notify { 'This module is only compatible with FreeRADIUS 3.': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -158,6 +158,16 @@ class freeradius (
     }
   }
 
+  # Add trigger.conf snmp trap configuration 
+  file { "${freeradius::fr_basepath}/trigger.conf":
+    ensure  => file,
+    mode    => '0644',
+    owner   => 'root',
+    group   => $freeradius::fr_group,
+    content => template('freeradius/trigger.conf.erb'),
+    require => [Package[$freeradius::fr_package], Group[$freeradius::fr_group]],
+    notify  => Service['radiusd'],
+  }
   # Set up concat policy file, as there is only one global policy
   # We also add standard header and footer
   concat { 'freeradius policy.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@ class freeradius (
   Boolean $manage_logpath                                      = true,
   Optional[String] $package_ensure                             = 'installed',
   String $radacctdir                                           = $freeradius::params::radacctdir,
+  Array $snmp_traps                                            = [],
 ) inherits freeradius::params {
   if $freeradius::fr_version !~ /^3/ {
     notify { 'This module is only compatible with FreeRADIUS 3.': }
@@ -161,7 +162,7 @@ class freeradius (
   # Add trigger.conf snmp trap configuration 
   file { "${freeradius::fr_basepath}/trigger.conf":
     ensure  => file,
-    mode    => '0644',
+    mode    => '0640',
     owner   => 'root',
     group   => $freeradius::fr_group,
     content => template('freeradius/trigger.conf.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class freeradius (
   Boolean $manage_logpath                                      = true,
   Optional[String] $package_ensure                             = 'installed',
   String $radacctdir                                           = $freeradius::params::radacctdir,
-  Array $snmp_traps                                            = [],
+  Array $snmp_traps                                            = ['home_server_alive'],
 ) inherits freeradius::params {
   if $freeradius::fr_version !~ /^3/ {
     notify { 'This module is only compatible with FreeRADIUS 3.': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class freeradius (
   String $snmp_traps_enable                                    = 'disable',
   String $snmp_traps_community                                 = 'public',
   String $snmp_traps_dest                                      = '127.0.0.1',
-  Array $snmp_traps                                            = undef,
+  Array $snmp_traps_list                                       = [],
 ) inherits freeradius::params {
   if $freeradius::fr_version !~ /^3/ {
     notify { 'This module is only compatible with FreeRADIUS 3.': }
@@ -161,7 +161,7 @@ class freeradius (
       preserve => true,
     }
   }
-  if empty($snmp_traps) {
+  if empty($snmp_traps_list) {
     $snmp_traps = [
       'server_start',
       'server_stop',
@@ -187,6 +187,8 @@ class freeradius (
       'server_sql_module_connection_fail',
       'server_sql_module_hup',
     ]
+  } else {
+    $snmp_traps = $snmp_traps_list
   }
   # Add trigger.conf snmp trap configuration 
   file { "${freeradius::fr_basepath}/trigger.conf":

--- a/templates/trigger.conf.erb
+++ b/templates/trigger.conf.erb
@@ -120,8 +120,8 @@ trigger {
         #
         server {
                 # the server has just started
-                <% unless @snmp_traps.include?('home_server_alive') %># <% end %>
-                start = "${snmptrap}::serverStart"
+                <% unless @snmp_traps.include?('home_server_alive') %>
+                # <% end %>start = "${snmptrap}::serverStart"
                 
 
 

--- a/templates/trigger.conf.erb
+++ b/templates/trigger.conf.erb
@@ -71,7 +71,7 @@ snmp {
                 #  You can disable traps by changing the command to
                 #  "/bin/echo".
                 #
-                <%- if @ensure = 'present' -%>
+                <%- if @snmp_traps_enable = 'enable' -%>
                 cmd = "/usr/bin/snmptrap -v2c"
                 <%- else -%>
                 cmd = "/bin/echo"
@@ -80,12 +80,12 @@ snmp {
                 #
                 #  Community string
                 #
-                community = "<%= @trap_community %>"
+                community = "<%= @snmp_traps_community %>"
 
                 #
                 #  Agent configuration.
                 #
-                agent = "<%= @trap_dest %> ''"
+                agent = "<%= @snmp_traps_dest %> ''"
         }
 }
 

--- a/templates/trigger.conf.erb
+++ b/templates/trigger.conf.erb
@@ -1,0 +1,288 @@
+# -*- text -*-
+##
+## trigger.conf -- Events in the server can trigger a hook to be executed.
+##
+##      $Id: 413a182eec6a193ef8ffd284295e181962265395 $
+
+#
+#  The triggers are named as "type.subtype.value".  These names refer
+#  to subsections and then configuration items in the "trigger"
+#  section below.  When an event occurs, the trigger is executed.  The
+#  trigger is simply a program that is run, with optional arguments.
+#
+#  The server does not wait when a trigger is executed.  It is simply
+#  a "one-shot" event that is sent.
+#
+#  The trigger names should be self-explanatory.
+#
+
+#
+#  SNMP configuration.
+#
+#  For now, this is only for SNMP traps.
+#
+#  They are enabled by uncommenting (or adding) "$INCLUDE trigger.conf"
+#  in the main "radiusd.conf" file.
+#
+#  The traps *REQUIRE* that the files in the "mibs" directory be copied
+#  to the global mibs directory, usually /usr/share/snmp/mibs/.
+#  If this is not done, the "snmptrap" program has no idea what information
+#  to send, and will not work.  The MIB installation is *NOT* done as
+#  part of the default installation, so that step *MUST* be done manually.
+#
+#  The global MIB directory can be found by running the following command:
+#
+#       snmptranslate -Dinit_mib .1.3 2>&1 | grep MIBDIR | sed "s/' .*//;s/.* '//;s/.*://"
+#
+#  Or maybe just:
+#
+#       snmptranslate -Dinit_mib .1.3 2>&1 | grep MIBDIR
+#
+#  If you have copied the MIBs to that directory, you can test the
+#  FreeRADIUS MIBs by running the following command:
+#
+#       snmptranslate -m +FREERADIUS-NOTIFICATION-MIB -IR -On  serverStart
+#
+#  It should print out:
+#
+#       .1.3.6.1.4.1.11344.4.1.1
+#
+#  As always, run the server in debugging mode after enabling the
+#  traps.  You will see the "snmptrap" command being run, and it will
+#  print out any errors or issues that it encounters.  Those need to
+#  be fixed before running the server in daemon mode.
+#
+#  We also suggest running in debugging mode as the "radiusd" user, if
+#  you have "user/group" set in radiusd.conf.  The "snmptrap" program
+#  may behave differently when run as "root" or as the "radiusd" user.
+#
+snmp {
+        #
+        #  Configuration for SNMP traps / notifications
+        #
+        #  To disable traps, edit "radiusd.conf", and delete the line
+        #  which says "$INCUDE trigger.conf"
+        #
+        trap {
+                #
+                #  Absolute path for the "snmptrap" command, and
+                #  default command-line arguments.
+                #
+                #  You can disable traps by changing the command to
+                #  "/bin/echo".
+                #
+                <%- if @ensure = 'present' -%>
+                cmd = "/usr/bin/snmptrap -v2c"
+                <%- else -%>
+                cmd = "/bin/echo"
+                <%- end -%>
+
+                #
+                #  Community string
+                #
+                community = "<%= @trap_community %>"
+
+                #
+                #  Agent configuration.
+                #
+                agent = "<%= @trap_dest %> ''"
+        }
+}
+
+#
+#  The "snmptrap" configuration defines the full command used to run the traps.
+#
+#  This entry should not be edited.  Instead, edit the "trap" section above.
+#
+snmptrap = "${snmp.trap.cmd} -c ${snmp.trap.community} ${snmp.trap.agent} FREERADIUS-NOTIFICATION-MIB"
+
+#
+#  The individual triggers are defined here.  You can disable one by
+#  deleting it, or by commenting it out.  You can disable an entire
+#  section of traps by deleting the section.
+#
+#  The entries below should not be edited.  For example, the double colons
+#  *must* immediately follow the ${snmptrap} reference.  Adding a space
+#  before the double colons  will break all SNMP traps.
+#
+#  However... the traps are just programs which are run when
+#  particular events occur.  If you want to replace a trap with
+#  another program, you can.  Just edit the definitions below, so that
+#  they run a program of your choice.
+#
+#  For example, you can leverage the "start/stop" triggers to run a
+#  program when the server starts, or when it stops.  But that will
+#  prevent the start/stop SNMP traps from working, of course.
+#
+trigger {
+        #
+        # Events in the server core
+        #
+        server {
+                # the server has just started
+                <% unless @snmp_traps.include?('home_server_alive') %># <% end %>
+                start = "${snmptrap}::serverStart"
+                
+
+
+                # the server is about to stop
+                stop = "${snmptrap}::serverStop"
+
+                # The "max_requests" condition has been reached.
+                # This will trigger only once per 60 seconds.
+                max_requests = "${snmptrap}::serverMaxRequests"
+
+                # For events related to clients
+                client {
+                        #  Added a new dynamic client
+                        add = "/path/to/file %{Packet-Src-IP-Address}"
+
+                        #  There is no event for when dynamic clients expire
+                }
+
+                # Events related to signals received.
+                signal {
+                        # a HUP signal
+                        hup = "${snmptrap}::signalHup"
+
+                        # a TERM signal
+                        term = "${snmptrap}::signalTerm"
+                }
+
+
+                # Events related to the thread pool
+                thread {
+                       # A new thread has been started
+                       start = "${snmptrap}::threadStart"
+
+                       # an existing thread has been stopped
+                       stop = "${snmptrap}::threadStop"
+
+                       # an existing thread is unresponsive
+                       unresponsive = "${snmptrap}::threadUnresponsive"
+
+                       # the "max_threads" limit has been reached
+                       max_threads = "${snmptrap}::threadMaxThreads"
+                }
+        }
+
+        # When a home server changes state.
+        # These traps are edge triggered.
+        home_server {
+                # common arguments: IP, port, identifier
+                args = "radiusAuthServerAddress a %{proxy-request:Packet-Dst-IP-Address} radiusAuthClientServerPortNumber i %{proxy-request:Packet-Dst-Port} radiusAuthServIdent s '%{home_server:instance}'"
+
+                # The home server has been marked "alive"
+                alive = "${snmptrap}::homeServerAlive ${args}"
+
+                # The home server has been marked "zombie"
+                zombie = "${snmptrap}::homeServerZombie ${args}"
+
+                # The home server has been marked "dead"
+                dead = "${snmptrap}::homeServerDead ${args}"
+        }
+
+        # When a pool of home servers changes state.
+        home_server_pool {
+                # common arguments
+                args = "radiusdConfigName s %{home_server:instance}"
+
+                # It has reverted to "normal" mode, where at least one
+                # home server is alive.
+                normal = "${snmptrap}::homeServerPoolNormal ${args}"
+
+                # It is in "fallback" mode, with all home servers "dead"
+                fallback = "${snmptrap}::homeServerPoolFallback ${args}"
+        }
+
+        #  Triggers for specific modules.  These are NOT in the module
+        #  configuration because they are global to all instances of the
+        #  module.  You can have module-specific triggers, by placing a
+        #  "trigger" subsection in the module configuration.
+        modules {
+                # Common arguments
+                args = "radiusdModuleInstance s ''"
+
+                # The files module
+                files {
+                        # Common arguments
+                        args = "radiusdModuleName s files ${..args}"
+
+                        # The module has been HUP'd via radmin
+                        hup = "${snmptrap}::serverModuleHup ${args}"
+
+                        # Note that "hup" can be used for every module
+                        # which can be HUP'd via radmin
+                }
+
+                # The LDAP module
+                # If the server does "bind as user", it will open and close
+                # an LDAP connection ofr every "bind as user".  Be aware that
+                # this will likely produce a lot of triggers.
+                ldap {
+                        # Common arguments
+                        args = "radiusdModuleName s ldap ${..args}"
+
+                        # A new connection to the DB has been opened
+                        open = "${snmptrap}::serverModuleConnectionUp ${args}"
+
+                        # A connection to the DB has been closed
+                        close = "${snmptrap}::serverModuleConnectionDown ${args}"
+
+                        # The module has been HUP'd via radmin
+                        hup = "${snmptrap}::serverModuleHup ${args}"
+                }
+
+                # The SQL module
+                sql {
+                        # Common arguments
+                        args = "radiusdModuleName s sql ${..args}"
+
+                        # A new connection to the DB has been opened
+                        open = "${snmptrap}::serverModuleConnectionUp ${args}"
+
+                        # A connection to the DB has been closed
+                        close = "${snmptrap}::serverModuleConnectionDown ${args}"
+
+                        # Failed to open a new connection to the DB
+                        fail = "${snmptrap}::serverModuleConnectionFail ${args}"
+
+                        # The module has been HUP'd via radmin
+                        hup = "${snmptrap}::serverModuleHup ${args}"
+                }
+
+                # You can also use connection pool's start/stop/open/close triggers
+                # for any module which uses the "pool" section, here and under
+                # pool.trigger in module configuration.
+        }
+}
+
+#
+#  The complete list of triggers as generated from the source code is below.
+#
+#  These are the ONLY traps which are generated.  You CANNOT add new traps
+#  by defining them in one of the sections above.  New traps can be created
+#  only by edited both the source code to the server, *and* the MIBs.
+#  If you are not an expert in C and SNMP, then adding new traps will be
+#  difficult to create.
+#
+# home_server.alive
+# home_server.dead
+# home_server.zombie
+# home_server_pool.fallback
+# home_server_pool.normal
+# modules.*.hup
+# modules.ldap.timeout
+# modules.sql.close
+# modules.sql.fail
+# modules.sql.open
+# server.client.add
+# server.max_requests
+# server.signal.hup
+# server.signal.term
+# server.start
+# server.stop
+# server.thread.max_threads
+# server.thread.start
+# server.thread.stop
+# server.thread.unresponsive

--- a/templates/trigger.conf.erb
+++ b/templates/trigger.conf.erb
@@ -183,15 +183,15 @@ trigger {
 
                 # The home server has been marked "alive"
                 <% unless @snmp_traps.include?('home_server_alive') %>
-                # <% end %>salive = "${snmptrap}::homeServerAlive ${args}"
+                # <% end %>alive = "${snmptrap}::homeServerAlive ${args}"
 
                 # The home server has been marked "zombie"
                 <% unless @snmp_traps.include?('home_server_zombie') %>
-                # <% end %>szombie = "${snmptrap}::homeServerZombie ${args}"
+                # <% end %>zombie = "${snmptrap}::homeServerZombie ${args}"
 
                 # The home server has been marked "dead"
                 <% unless @snmp_traps.include?('home_server_dead') %>
-                # <% end %>sdead = "${snmptrap}::homeServerDead ${args}"
+                # <% end %>dead = "${snmptrap}::homeServerDead ${args}"
         }
 
         # When a pool of home servers changes state.
@@ -202,7 +202,7 @@ trigger {
                 # It has reverted to "normal" mode, where at least one
                 # home server is alive.
                 <% unless @snmp_traps.include?('home_server_pool_normal') %>
-                # <% end %>snormal = "${snmptrap}::homeServerPoolNormal ${args}"
+                # <% end %>normal = "${snmptrap}::homeServerPoolNormal ${args}"
 
                 # It is in "fallback" mode, with all home servers "dead"
                 <% unless @snmp_traps.include?('home_server_pool_fallback') %>

--- a/templates/trigger.conf.erb
+++ b/templates/trigger.conf.erb
@@ -120,22 +120,25 @@ trigger {
         #
         server {
                 # the server has just started
-                <% unless @snmp_traps.include?('home_server_alive') %>
+                <% unless @snmp_traps.include?('server_start') %>
                 # <% end %>start = "${snmptrap}::serverStart"
                 
 
 
                 # the server is about to stop
-                stop = "${snmptrap}::serverStop"
+                <% unless @snmp_traps.include?('server_stop') %>
+                # <% end %>stop = "${snmptrap}::serverStop"
 
                 # The "max_requests" condition has been reached.
                 # This will trigger only once per 60 seconds.
-                max_requests = "${snmptrap}::serverMaxRequests"
+                <% unless @snmp_traps.include?('server_max_requests') %>
+                # <% end %>max_requests = "${snmptrap}::serverMaxRequests"
 
                 # For events related to clients
                 client {
                         #  Added a new dynamic client
-                        add = "/path/to/file %{Packet-Src-IP-Address}"
+                        <% unless @snmp_traps.include?('server_client_add') %>
+                        # <% end %>add = "/path/to/file %{Packet-Src-IP-Address}"
 
                         #  There is no event for when dynamic clients expire
                 }
@@ -143,26 +146,32 @@ trigger {
                 # Events related to signals received.
                 signal {
                         # a HUP signal
-                        hup = "${snmptrap}::signalHup"
+                        <% unless @snmp_traps.include?('server_signal_hup') %>
+                        # <% end %>hup = "${snmptrap}::signalHup"
 
                         # a TERM signal
-                        term = "${snmptrap}::signalTerm"
+                        <% unless @snmp_traps.include?('server_signal_term') %>
+                        # <% end %>term = "${snmptrap}::signalTerm"
                 }
 
 
                 # Events related to the thread pool
                 thread {
-                       # A new thread has been started
-                       start = "${snmptrap}::threadStart"
+                        # A new thread has been started
+                        <% unless @snmp_traps.include?('server_thread_start') %>
+                        # <% end %>start = "${snmptrap}::threadStart"
 
-                       # an existing thread has been stopped
-                       stop = "${snmptrap}::threadStop"
+                        # an existing thread has been stopped
+                        <% unless @snmp_traps.include?('server_thread_stop') %>
+                        # <% end %>stop = "${snmptrap}::threadStop"
 
-                       # an existing thread is unresponsive
-                       unresponsive = "${snmptrap}::threadUnresponsive"
+                        # an existing thread is unresponsive
+                        <% unless @snmp_traps.include?('server_thread_Unresponsive') %>
+                        # <% end %>unresponsive = "${snmptrap}::threadUnresponsive"
 
-                       # the "max_threads" limit has been reached
-                       max_threads = "${snmptrap}::threadMaxThreads"
+                        # the "max_threads" limit has been reached
+                        <% unless @snmp_traps.include?('server_thread_max_threads') %>
+                        # <% end %>max_threads = "${snmptrap}::threadMaxThreads"
                 }
         }
 
@@ -173,13 +182,16 @@ trigger {
                 args = "radiusAuthServerAddress a %{proxy-request:Packet-Dst-IP-Address} radiusAuthClientServerPortNumber i %{proxy-request:Packet-Dst-Port} radiusAuthServIdent s '%{home_server:instance}'"
 
                 # The home server has been marked "alive"
-                alive = "${snmptrap}::homeServerAlive ${args}"
+                <% unless @snmp_traps.include?('home_server_alive') %>
+                # <% end %>salive = "${snmptrap}::homeServerAlive ${args}"
 
                 # The home server has been marked "zombie"
-                zombie = "${snmptrap}::homeServerZombie ${args}"
+                <% unless @snmp_traps.include?('home_server_zombie') %>
+                # <% end %>szombie = "${snmptrap}::homeServerZombie ${args}"
 
                 # The home server has been marked "dead"
-                dead = "${snmptrap}::homeServerDead ${args}"
+                <% unless @snmp_traps.include?('home_server_dead') %>
+                # <% end %>sdead = "${snmptrap}::homeServerDead ${args}"
         }
 
         # When a pool of home servers changes state.
@@ -189,10 +201,12 @@ trigger {
 
                 # It has reverted to "normal" mode, where at least one
                 # home server is alive.
-                normal = "${snmptrap}::homeServerPoolNormal ${args}"
+                <% unless @snmp_traps.include?('home_server_pool_normal') %>
+                # <% end %>snormal = "${snmptrap}::homeServerPoolNormal ${args}"
 
                 # It is in "fallback" mode, with all home servers "dead"
-                fallback = "${snmptrap}::homeServerPoolFallback ${args}"
+                <% unless @snmp_traps.include?('home_server_pool_fallback') %>
+                # <% end %>fallback = "${snmptrap}::homeServerPoolFallback ${args}"
         }
 
         #  Triggers for specific modules.  These are NOT in the module
@@ -209,7 +223,8 @@ trigger {
                         args = "radiusdModuleName s files ${..args}"
 
                         # The module has been HUP'd via radmin
-                        hup = "${snmptrap}::serverModuleHup ${args}"
+                        <% unless @snmp_traps.include?('server_files_module_hup') %>
+                        # <% end %>hup = "${snmptrap}::serverModuleHup ${args}"
 
                         # Note that "hup" can be used for every module
                         # which can be HUP'd via radmin
@@ -224,13 +239,16 @@ trigger {
                         args = "radiusdModuleName s ldap ${..args}"
 
                         # A new connection to the DB has been opened
-                        open = "${snmptrap}::serverModuleConnectionUp ${args}"
+                        <% unless @snmp_traps.include?('server_ldap_module_connection_up') %>
+                        # <% end %>open = "${snmptrap}::serverModuleConnectionUp ${args}"
 
                         # A connection to the DB has been closed
-                        close = "${snmptrap}::serverModuleConnectionDown ${args}"
+                        <% unless @snmp_traps.include?('server_ldap_module_connection_down') %>
+                        # <% end %>close = "${snmptrap}::serverModuleConnectionDown ${args}"
 
                         # The module has been HUP'd via radmin
-                        hup = "${snmptrap}::serverModuleHup ${args}"
+                        <% unless @snmp_traps.include?('server_ldap_module_hup') %>
+                        # <% end %>hup = "${snmptrap}::serverModuleHup ${args}"
                 }
 
                 # The SQL module
@@ -239,16 +257,20 @@ trigger {
                         args = "radiusdModuleName s sql ${..args}"
 
                         # A new connection to the DB has been opened
-                        open = "${snmptrap}::serverModuleConnectionUp ${args}"
+                        <% unless @snmp_traps.include?('server_sql_module_connection_up') %>
+                        # <% end %>open = "${snmptrap}::serverModuleConnectionUp ${args}"
 
                         # A connection to the DB has been closed
-                        close = "${snmptrap}::serverModuleConnectionDown ${args}"
+                        <% unless @snmp_traps.include?('server_sql_module_connection_close') %>
+                        # <% end %>close = "${snmptrap}::serverModuleConnectionDown ${args}"
 
                         # Failed to open a new connection to the DB
-                        fail = "${snmptrap}::serverModuleConnectionFail ${args}"
+                        <% unless @snmp_traps.include?('server_sql_module_connection_fail') %>
+                        # <% end %>fail = "${snmptrap}::serverModuleConnectionFail ${args}"
 
                         # The module has been HUP'd via radmin
-                        hup = "${snmptrap}::serverModuleHup ${args}"
+                        <% unless @snmp_traps.include?('server_sql_module_hup') %>
+                        # <% end %>hup = "${snmptrap}::serverModuleHup ${args}"
                 }
 
                 # You can also use connection pool's start/stop/open/close triggers

--- a/templates/trigger.conf.erb
+++ b/templates/trigger.conf.erb
@@ -71,7 +71,7 @@ snmp {
                 #  You can disable traps by changing the command to
                 #  "/bin/echo".
                 #
-                <%- if @snmp_traps_enable = 'enable' -%>
+                <%- if @snmp_traps_enable == 'enable' -%>
                 cmd = "/usr/bin/snmptrap -v2c"
                 <%- else -%>
                 cmd = "/bin/echo"


### PR DESCRIPTION
Added a template for trigger.conf and 4 new parameters for freeradius class

- $snmp_traps_enable - Whether to actual trap and not just echo commands
- $snmp_traps_community - The SNMP community string/shared secret of the trap destination
- $snmp_traps_dest - The IP address of the trap destination
- $snmp_traps - And array of trap names, if empty it is populated with all trap names, if a list of traps is supplied then those are enabled.

There are no dependencies between parameters to allow full configuration of file and checking before enabling traps
