### PR TITLE
Allow managet logrotates and disable logrotate for for Debian by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class freeradius (
   Boolean $preserve_mods                                       = true,
   Boolean $correct_escapes                                     = true,
   Boolean $manage_logpath                                      = true,
+  Boolean $manage_logrotate                                    = true,
   Optional[String] $package_ensure                             = 'installed',
   String $radacctdir                                           = $freeradius::params::radacctdir,
 ) inherits freeradius::params {
@@ -428,37 +429,39 @@ class freeradius (
     }
   }
 
-  logrotate::rule { 'radacct':
-    path          => "${freeradius::fr_logpath}/radacct/*/*.log",
-    rotate_every  => 'day',
-    rotate        => 7,
-    create        => false,
-    missingok     => true,
-    compress      => true,
-    postrotate    => "kill -HUP `cat ${freeradius::fr_pidfile}`",
-    sharedscripts => true,
-  }
+  if $manage_logpath {
+    logrotate::rule { 'radacct':
+      path          => "${freeradius::fr_logpath}/radacct/*/*.log",
+      rotate_every  => 'day',
+      rotate        => 7,
+      create        => false,
+      missingok     => true,
+      compress      => true,
+      postrotate    => "kill -HUP `cat ${freeradius::fr_pidfile}`",
+      sharedscripts => true,
+    }
 
-  logrotate::rule { 'checkrad':
-    path          => "${freeradius::fr_logpath}/checkrad.log",
-    rotate_every  => 'week',
-    rotate        => 1,
-    create        => true,
-    missingok     => true,
-    compress      => true,
-    postrotate    => "kill -HUP `cat ${freeradius::fr_pidfile}`",
-    sharedscripts => true,
-  }
+    logrotate::rule { 'checkrad':
+      path          => "${freeradius::fr_logpath}/checkrad.log",
+      rotate_every  => 'week',
+      rotate        => 1,
+      create        => true,
+      missingok     => true,
+      compress      => true,
+      postrotate    => "kill -HUP `cat ${freeradius::fr_pidfile}`",
+      sharedscripts => true,
+    }
 
-  logrotate::rule { 'radiusd':
-    path          => "${freeradius::fr_logpath}/radius*.log",
-    rotate_every  => 'week',
-    rotate        => 26,
-    create        => true,
-    missingok     => true,
-    compress      => true,
-    postrotate    => "kill -HUP `cat ${freeradius::fr_pidfile}`",
-    sharedscripts => true,
+    logrotate::rule { 'radiusd':
+      path          => "${freeradius::fr_logpath}/radius*.log",
+      rotate_every  => 'week',
+      rotate        => 26,
+      create        => true,
+      missingok     => true,
+      compress      => true,
+      postrotate    => "kill -HUP `cat ${freeradius::fr_pidfile}`",
+      sharedscripts => true,
+    }
   }
 
   # Placeholder resource for dh and random as they are dynamically generated, so they

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class freeradius (
   Boolean $preserve_mods                                       = true,
   Boolean $correct_escapes                                     = true,
   Boolean $manage_logpath                                      = true,
-  Boolean $manage_logrotate                                    = true,
+  Boolean $manage_logrotate                                    = $freeradius::params::manage_logrotate,
   Optional[String] $package_ensure                             = 'installed',
   String $radacctdir                                           = $freeradius::params::radacctdir,
 ) inherits freeradius::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -188,4 +188,9 @@ class freeradius::params {
 
   # Default radsniff pid file location
   $fr_radsniff_pidfile = "/var/run/${fr_service}/radsniff.pid"
+
+  $manage_logrotate = $::osfamily ? {
+    'Debian' => false,
+    default  => true,
+  }
 }


### PR DESCRIPTION
Debian freeradius package installes own logrotate configs.

This patch adds option `manage_logrotate` and set for Debian `false` by default and for other keeps original (`true`) functionality (install logrotate configs).