### PR TITLE
Remove is_ip_address function removed from stdlib in 9.x

### DIFF
--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -1,29 +1,20 @@
 # == Define freeradius::listen
 #
 define freeradius::listen (
-  Freeradius::Ensure $ensure                                = 'present',
-  Enum['auth','acct','proxy','detail','status','coa'] $type = 'auth',
-  Optional[String] $ip                                      = undef,
-  Optional[String] $ip6                                     = undef,
-  Integer $port                                             = 0,
-  Optional[String] $interface                               = undef,
-  Optional[String] $virtual_server                          = undef,
-  Array[String] $clients                                    = [],
-  Integer $max_connections                                  = 16,
-  Integer $lifetime                                         = 0,
-  Integer $idle_timeout                                     = 30,
+  Freeradius::Ensure $ensure                                 = 'present',
+  Enum['auth','acct','proxy','detail','status','coa'] $type  = 'auth',
+  Optional[Variant[Stdlib::IP::Address::V4, Enum['*']]] $ip  = undef,
+  Optional[Variant[Stdlib::IP::Address::V6, Enum['*']]] $ip6 = undef,
+  Integer $port                                              = 0,
+  Optional[String] $interface                                = undef,
+  Optional[String] $virtual_server                           = undef,
+  Array[String] $clients                                     = [],
+  Integer $max_connections                                   = 16,
+  Integer $lifetime                                          = 0,
+  Integer $idle_timeout                                      = 30,
 ) {
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
-
-  # Parameter validation
-  if $ip and $ip != '*' and !is_ip_address($ip) {
-    fail('ip must be a valid IP address or \'*\'')
-  }
-
-  if $ip6 and $ip6 != '::' and !is_ip_address($ip6) {
-    fail('ip6 must be a valid IP address or \'::\'')
-  }
 
   if $ip and $ip6 {
     fail('Only one of ip or ip6 can be used')

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.25.0 <10.0.0"
+      "version_requirement": ">=5.0.0 <10.0.0"
     },
     {
       "name": "puppetlabs/firewall",


### PR DESCRIPTION
Bump the lower bound on stdlib to 5.0.0