### PR TITLE
Update calls to firewall module

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -61,17 +61,18 @@ define freeradius::client (
     if $port {
       if $ip {
         firewall { "100 ${name} ${port_description} v4":
-          proto  => 'udp',
-          dport  => $port,
-          action => 'accept',
-          source => $ip,
+          proto    => 'udp',
+          dport    => $port,
+          jump     => 'ACCEPT',
+          protocol => 'IPv4',
+          source   => $ip,
         }
       } elsif $ip6 {
         firewall { "100 ${name} ${port_description} v6":
           proto    => 'udp',
           dport    => $port,
-          action   => 'accept',
-          provider => 'ip6tables',
+          jump     => 'ACCEPT',
+          protocol => 'IPv6',
           source   => $ip6,
         }
       }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">=1.0.0 <7.0.0"
+      "version_requirement": ">=7.0.0 <9.0.0"
     },
     {
       "name": "saz/rsyslog",

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -85,8 +85,9 @@ describe 'freeradius::client' do
         is_expected.to contain_firewall('100 test 1234 v4')
           .with_proto('udp')
           .with_dport(1234)
-          .with_action('accept')
+          .with_jump('ACCEPT')
           .with_source('1.2.3.4')
+          .with_protocol('IPv4')
       end
 
       context 'with ipv6' do
@@ -102,9 +103,9 @@ describe 'freeradius::client' do
           is_expected.to contain_firewall('100 test 1234 v6')
             .with_proto('udp')
             .with_dport(1234)
-            .with_action('accept')
+            .with_jump('ACCEPT')
             .with_source('2001:db8::100')
-            .with_provider('ip6tables')
+            .with_protocol('IPv6')
         end
       end
     end
@@ -120,7 +121,7 @@ describe 'freeradius::client' do
         is_expected.to contain_firewall('100 test 1234,4321 v4')
           .with_proto('udp')
           .with_dport([1234, 4321])
-          .with_action('accept')
+          .with_jump('ACCEPT')
           .with_source('1.2.3.4')
       end
 
@@ -137,9 +138,9 @@ describe 'freeradius::client' do
           is_expected.to contain_firewall('100 test 1234,4321 v6')
             .with_proto('udp')
             .with_dport([1234, 4321])
-            .with_action('accept')
+            .with_jump('ACCEPT')
             .with_source('2001:db8::100')
-            .with_provider('ip6tables')
+            .with_protocol('IPv6')
         end
       end
     end


### PR DESCRIPTION
The puppetlabs firewall module had some breaking changes in v7. Of interest are the "action" parameter being removed in favour of "jump" and the "provider" parameter being removed to specify ip6tables etc. in favour of "protocol".

This PR updates the module and uses the newer parameters, which will also fix tests on #217 if rebased.