### PR TITLE
Publish on new release only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Build and publish to Puppet Forge
 
 on:
- push:
-  tags:
-      - [0-9]+.[0-9]+.[0-9]+
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
Run publish workflow on new GH release, not when tags are pushed