### PR TITLE
Bugfix cannot reassign variable fr_service

### DIFF
--- a/manifests/module/ldap.pp
+++ b/manifests/module/ldap.pp
@@ -74,7 +74,7 @@ define freeradius::module::ldap (
   # FR3.1 format server = 'ldap1.example.com'
   #              server = 'ldap2.example.com'
   #              server = 'ldap3.example.com'
-  $serverconcatarray = $::freeradius_version ? {
+  $serverconcatarray = $facts['freeradius_version'] ? {
     /^3\.0\./ => any2array(join($server, ',')),
     default   => $server,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,7 +75,7 @@ class freeradius::params {
   }
 
   # Whether the FreeRADIUS init.d startup script has a status setting or not
-  $fr_service = $facts['os']['family'] ? {
+  $fr_service_has_status = $facts['os']['family'] ? {
     'RedHat' => true,
     'Debian' => true,
     default  => false,


### PR DESCRIPTION
My apologies. I changed a variable name in my last PR, causing this:

```
Evaluation Error: Cannot reassign variable '$fr_service' (file: **modules/freeradius/manifests/params.pp, line: 78, column: 15)
```

There's also an unrelated error where `ldap` is looking for the version fact as an top-level (legacy) fact.

```
Evaluation Error: Unknown variable: '::freeradius_version'. (file: **/modules/freeradius/manifests/module/ldap.pp, line: 77, column: 24)
```