### PR TITLE
Ubuntu 24 and puppet systemd

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,7 @@ class freeradius::params {
         '18.04' => '3',
         '20.04' => '3',
         '22.04' => '3',
+        '24.04' => '3',
         default => '2',
       }
     }
@@ -99,6 +100,7 @@ class freeradius::params {
         '18.04'      => '/etc/freeradius/3.0',
         '20.04'      => '/etc/freeradius/3.0',
         '22.04'      => '/etc/freeradius/3.0',
+        '24.04'      => '/etc/freeradius/3.0',
         default      => '/etc/freeradius',
       }
       $fr_raddbdir = $::operatingsystemmajrelease ? {
@@ -109,6 +111,7 @@ class freeradius::params {
         '18.04'      => "\${sysconfdir}/freeradius/3.0",
         '20.04'      => "\${sysconfdir}/freeradius/3.0",
         '22.04'      => "\${sysconfdir}/freeradius/3.0",
+        '24.04'      => "\${sysconfdir}/freeradius/3.0",
         default      => "\${sysconfdir}/freeradius",
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">=3.0.0 <6.3.0"
+      "version_requirement": ">=3.0.0 <6.4.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">=3.0.0 <6.0.0"
+      "version_requirement": ">=3.0.0 <6.3.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Added default Params for Ubuntu 24.04 and Puppet-Systemd lifted to 6.4 from 6.3