### PR TITLE
Use name instead of shortname for client definition

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -40,9 +40,9 @@ define freeradius::client (
   $fr_basepath = $::freeradius::params::fr_basepath
   $fr_group    = $::freeradius::params::fr_group
 
-  file { "freeradius clients.d/${shortname}.conf":
+  file { "freeradius clients.d/${name}.conf":
     ensure  => $ensure,
-    path    => "${fr_basepath}/clients.d/${shortname}.conf",
+    path    => "${fr_basepath}/clients.d/${name}.conf",
     mode    => '0640',
     owner   => 'root',
     group   => $fr_group,

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -14,8 +14,8 @@ describe 'freeradius::client' do
   end
 
   it do
-    is_expected.to contain_file('freeradius clients.d/test_short.conf')
-      .with_path('/etc/raddb/clients.d/test_short.conf')
+    is_expected.to contain_file('freeradius clients.d/test.conf')
+      .with_path('/etc/raddb/clients.d/test.conf')
       .with_content(%r{^client test_short {\n\s+ipaddr = 1.2.3.4\n\s+proto = \*\n\s+shortname = test_short\n\s+secret = "secret_value"\n\s+require_message_authenticator = no\n}\n})
       .with_ensure('present')
       .with_group('radiusd')
@@ -58,7 +58,7 @@ describe 'freeradius::client' do
     end
 
     it do
-      is_expected.to contain_file('freeradius clients.d/test_short.conf')
+      is_expected.to contain_file('freeradius clients.d/test.conf')
         .with_content(%r{^\s+password = "foo bar"$})
     end
   end


### PR DESCRIPTION
* Fix after #191 which reverted changes from #198