### PR TITLE
Policy file content option for using templates

### DIFF
--- a/manifests/policy.pp
+++ b/manifests/policy.pp
@@ -1,7 +1,7 @@
 # Install FreeRADIUS policies
 define freeradius::policy (
-  Optional[String] $source,
-  Optional[String] $content,
+  Optional[String] $source = undef,
+  Optional[String] $content = undef,
   Optional[Integer] $order   = 50,
   Freeradius::Ensure $ensure = present,
 ) {

--- a/manifests/policy.pp
+++ b/manifests/policy.pp
@@ -1,6 +1,7 @@
 # Install FreeRADIUS policies
 define freeradius::policy (
   Optional[String] $source,
+  Optional[String] $content,
   Optional[Integer] $order   = 50,
   Freeradius::Ensure $ensure = present,
 ) {
@@ -15,6 +16,7 @@ define freeradius::policy (
     owner   => 'root',
     group   => $fr_group,
     source  => $source,
+    content => $content,
     require => [Package['freeradius'], Group['radiusd']],
     notify  => Service['radiusd'],
   }


### PR DESCRIPTION
Hi @djjudas21, an environment I'm managing using data from hiera to construct a policy for adding VSAs to responses.  Currently this is done in the sites file using a template, and about 50 lines of if, elsif, and case statements is untidy, so I've added a content option to policy.pp so a template can populate the policy file.

Probably something for Monday, but its working fine in my environment 