### PR TITLE
Increasing timeout for response from LDAP server

### DIFF
--- a/manifests/module/ldap.pp
+++ b/manifests/module/ldap.pp
@@ -62,6 +62,8 @@ define freeradius::module::ldap (
   Integer $lifetime                                                   = 0,
   Integer $idle_timeout                                               = 60,
   Optional[Float] $connect_timeout                                    = undef,
+  Integer $net_timeout                                                = 1,
+
 ) {
   $fr_package          = $::freeradius::params::fr_package
   $fr_service          = $::freeradius::params::fr_service

--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -642,7 +642,7 @@ ldap <%= @name %> {
 		#  failures) default: 10
 		#
 		#  LDAP_OPT_NETWORK_TIMEOUT is set to this value.
-		net_timeout = 1
+		net_timeout = <%= @net_timeout %>
 
 		#  LDAP_OPT_X_KEEPALIVE_IDLE
 		idle = <%= @idle %>


### PR DESCRIPTION
Hi @djjudas21 

When multi-factor authentication is implemented within an LDAP server, it does not respond until user responds. 

Setting net_timeout to more than 1 second stops FreeRadius timing out waiting, but the default is still 1 second