### PR TITLE
Remove subdirectories of $purged_dirs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,7 @@ class freeradius (
       path    => $path,
       purge   => true,
       recurse => true,
+      force   => true,
       mode    => '0755',
       owner   => 'root',
       group   => $freeradius::fr_group,


### PR DESCRIPTION
Hi @djjudas21 

FreeRadius installation (Mine is 3.2.5) now adds directory `realms` as a subdirectory of `certs`, which the current file resource purge cannot delete, causing these messages and restarting FreeRadius on every puppet run.
```
Notice: /Stage[main]/Freeradius/File[/etc/freeradius/3.0/certs/realms]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Freeradius/File[/etc/freeradius/3.0/certs/realms]/ensure: removed (corrective)
Debug: /Stage[main]/Freeradius/File[/etc/freeradius/3.0/certs/realms]: The container freeradius certs will propagate my refresh event
```
<br>
I have set force to purge the subdirectory and stop this problem.

This can also be fixed with a resource collector hack in the puppet profile, but this is cleaner