### PR TITLE
Expose ldap allow_dangling_group_ref as a configurable option in ldap.pp

### DIFF
--- a/manifests/module/ldap.pp
+++ b/manifests/module/ldap.pp
@@ -27,6 +27,7 @@ define freeradius::module::ldap (
   Optional[Freeradius::Boolean] $group_cacheable_name                 = undef,
   Optional[Freeradius::Boolean] $group_cacheable_dn                   = undef,
   Optional[String] $group_cache_attribute                             = undef,
+  Optional[Freeradius::Boolean] $group_allow_dangling_ref             = undef,
   Optional[String] $group_attribute                                   = undef,
   Optional[String] $profile_filter                                    = undef,
   Optional[String] $profile_default                                   = undef,

--- a/spec/defines/module/ldap_spec.rb
+++ b/spec/defines/module/ldap_spec.rb
@@ -11,6 +11,7 @@ describe 'freeradius::module::ldap' do
       password: 'test password',
       basedn: 'dc=example,dc=com',
       server: ['localhost'],
+      group_allow_dangling_ref: 'yes',
     }
   end
 
@@ -35,6 +36,7 @@ describe 'freeradius::module::ldap' do
       .with_content(%r{^\s+password = 'test password'\n})
       .with_content(%r{^\s+base_dn = 'dc=example,dc=com'\n})
       .with_content(%r{^\s+update \{\n})
+      .with_content(%r{^\s+allow_dangling_group_ref = 'yes'\n})
       .without_content(%r{^\s+connect_timeout = .*})
       .with_ensure('present')
       .with_group('radiusd')

--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -423,6 +423,9 @@ ldap <%= @name %> {
 		#  When set to 'yes', this option ignores invalid DN
 		#  references.
 #		allow_dangling_group_ref = 'no'
+<%- if @group_allow_dangling_ref -%>
+		allow_dangling_group_ref = '<%= @group_allow_dangling_ref %>'
+<%- end -%>
 	}
 
 	#


### PR DESCRIPTION
Expose ldap allow_dangling_group_ref as a configurable option in ldap.pp